### PR TITLE
Issue/51 adding support for prettier 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
 
+**Note:** requires `prettier` version 1.7.0+
+
+***
+
 By default it will auto format **javascript**, **typescript**, **less**, **scss**, **css**, **json**, and **graphql** files that have "@format" annotation in the header of the file.
 
 ![vim-prettier](/media/vim-prettier.gif?raw=true "vim-prettier")

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ g:prettier#config#trailing_comma = 'all'
 
 " flow|babylon|typescript|postcss|json|graphql
 g:prettier#config#parser = 'flow'
+
+" cli-override|file-override|prefer-file
+g:prettier#config#config_precedence = 'prefer-file'
 ```
 
 ### REQUIREMENT(S)

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -190,6 +190,8 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ get(a:config, 'trailingComma', g:prettier#config#trailing_comma) .
           \ ' --parser ' .
           \ get(a:config, 'parser', g:prettier#config#parser) .
+          \ ' --config-precedence ' .
+          \ get(a:config, 'configPrecedence', g:prettier#config#config_precedence) .
           \ ' --stdin '
   return cmd
 endfunction

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -123,6 +123,9 @@ However they can be configured by:
 
   " flow|babylon|typescript|postcss|json|graphql
   g:prettier#config#parser = 'flow'
+
+  " cli-override|file-override|prefer-file
+  g:prettier#config#config_precedence = 'prefer-file'
 <
 ==============================================================================
 REQUIREMENT(S)                                      *vim-prettier-requirements*

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -14,6 +14,8 @@ INTRODUCTION                                        *vim-prettier-introduction*
 A vim plugin wrapper for prettier, pre-configured with 
 custom default prettier settings.
 
+**Note:** requires `prettier` version 1.7.0+
+
 By default it will auto format javascript, typescript, less, scss, css,
 json, and graphql files that have '@format' annotation in the header of the file.
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "dependencies": {
-    "prettier": "^1.5.3"
+    "prettier": "^1.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vim-prettier",
   "author": "Mitermayer Reis <mitermayer.reis@gmail.com>",
-  "version": "0.0.15",
+  "version": "0.1.0",
   "description": "Vim plugin for prettier",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "dependencies": {
-    "prettier": "^1.6.1"
+    "prettier": "^1.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "dependencies": {
-    "prettier": "^1.6.2"
+    "prettier": "^1.7.0"
   }
 }

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -5,7 +5,7 @@
 " Name Of File: prettier.vim
 "  Description: A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
 "   Maintainer: Mitermayer Reis <mitermayer.reis at gmail.com>
-"      Version: 0.0.15
+"      Version: 0.1.0
 "        Usage: Use :help vim-prettier-usage, or visit https://github.com/prettier/vim-prettier
 "
 "==========================================================================================================

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -54,6 +54,9 @@ let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 
 " flow|babylon|typescript|postcss|json|graphql
 let g:prettier#config#parser = get(g:,'prettier#config#parser', 'flow')
 
+" cli-override|file-override|prefer-file
+let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_precedence', 'prefer-file')
+
 " synchronous by default
 command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>)
 


### PR DESCRIPTION
This PR adds full support for prettier 1.7 including the project based configuration.

This can only be merged once this https://github.com/prettier/prettier/pull/2733 is present on a new prettier release.

Will also bump `vim-prettier` to minor release since the new configuration `--config-precedence` is incompatible with older prettier CLI versions

fixes: https://github.com/prettier/vim-prettier/issues/51