### PR TITLE
issue/56 - Allowing user path overwrite configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ When installed via vim-plug, a default prettier executable is installed inside v
 
 vim-prettier executable resolution:
 
-1. Traverse parents and search for Prettier installation inside `node_modules`
-2. Look for a global prettier installation
-3. Use locally installed vim-prettier prettier executable
+1. Look for user defined prettier cli path from vim configuration file
+2. Traverse parents and search for Prettier installation inside `node_modules`
+3. Look for a global prettier installation
+4. Use locally installed vim-prettier prettier executable
 
 ### USAGE
 
@@ -89,6 +90,12 @@ Disable auto formatting of files that have "@format" tag
 
 ```vim
 let g:prettier#autoformat = 0
+```
+
+Set the prettier CLI executable path
+
+```vim
+let g:prettier#exec_cmd_path = "~/path/to/cli/prettier"
 ```
 
 The command `:Prettier` by default is synchronous but can also be forced async

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -218,11 +218,17 @@ function! s:Get_Prettier_Exec_Args(config) abort
 endfunction
 
 " By default we will search for the following
+" => user defined prettier cli path from vim configuration file
 " => locally installed prettier inside node_modules on any parent folder
 " => globally installed prettier
 " => vim-prettier prettier installation
 " => if all fails suggest install
 function! s:Get_Prettier_Exec() abort
+  let l:user_defined_exec_path = fnamemodify(g:prettier#exec_cmd_path, ':p')
+  if executable(l:user_defined_exec_path)
+    return l:user_defined_exec_path
+  endif
+
   let l:local_exec = s:Get_Prettier_Local_Exec()
   if executable(l:local_exec)
     return l:local_exec

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -24,9 +24,10 @@ When installed via vim-plug, a default prettier executable is installed inside
 
 vim-prettier executable resolution:
 
-1. Traverse parents and search for Prettier installation inside `node_modules`
-2. Look for a global prettier installation
-3. Use locally installed vim-prettier prettier executable
+1. Look for user defined prettier cli path from vim configuration file
+2. Traverse parents and search for Prettier installation inside `node_modules`
+3. Look for a global prettier installation
+4. Use locally installed vim-prettier prettier executable
 
 ==============================================================================
 INSTALL                                                  *vim-prettier-install*
@@ -80,6 +81,10 @@ CONFIGURATION                                       *vim-prettier-configuration*
 Disable auto formatting of files that have "@format" tag 
 >
   let g:prettier#autoformat = 0
+<
+Set the prettier CLI executable path
+>
+  let g:prettier#exec_cmd_path = "~/path/to/cli/prettier"
 <
 The command `:Prettier` by default is synchronous but can also be forced async
 >

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -20,6 +20,9 @@ let g:loaded_prettier = 1
 " autoformating enabled by default upon saving
 let g:prettier#autoformat = get(g:, 'prettier#autoformat', 1)
 
+" path to prettier cli
+let g:prettier#exec_cmd_path = get(g:, 'prettier#exec_cmd_path', 0)
+
 " calling :Prettier by default runs synchronous
 let g:prettier#exec_cmd_async = get(g:, 'prettier#exec_cmd_async', 0)
 


### PR DESCRIPTION
Allow user to set a the prettier CLI path via vim configuration.

fixes: https://github.com/prettier/vim-prettier/issues/56