### PR TITLE
bug: Fixing config overwrite value for non js by levaraging --stdin-f…

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -213,6 +213,8 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ get(a:config, 'parser', g:prettier#config#parser) .
           \ ' --config-precedence ' .
           \ get(a:config, 'configPrecedence', g:prettier#config#config_precedence) .
+          \ ' --stdin-filepath ' .
+          \ simplify(expand("%:t")) .
           \ ' --stdin '
   return l:cmd
 endfunction

--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -1,8 +1,3 @@
-let b:prettier_ft_default_args = {
-  \ 'parser': 'css',
-  \ 'configPrecedence': 'cli-override',
-  \ }
-
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -1,8 +1,3 @@
-let b:prettier_ft_default_args = {
-  \ 'parser': 'graphql',
-  \ 'configPrecedence': 'cli-override',
-  \ }
-
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -1,9 +1,3 @@
-let b:prettier_ft_default_args = {
-  \ 'parser': 'json',
-  \ 'trailingComma': 'none',
-  \ 'configPrecedence': 'cli-override',
-  \ }
-
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -1,8 +1,3 @@
-let b:prettier_ft_default_args = {
-  \ 'parser': 'less',
-  \ 'configPrecedence': 'cli-override',
-  \ }
-
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/scss.vim
+++ b/ftplugin/scss.vim
@@ -1,8 +1,3 @@
-let b:prettier_ft_default_args = {
-  \ 'parser': 'scss',
-  \ 'configPrecedence': 'cli-override',
-  \ }
-
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,8 +1,3 @@
-let b:prettier_ft_default_args = {
-  \ 'parser': 'typescript',
-  \ 'configPrecedence': 'cli-override',
-  \ }
-
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "dependencies": {
-    "prettier": "^1.7.2"
+    "prettier": "^1.7.4"
   }
 }


### PR DESCRIPTION
Due to a bug where prettier would not allow parser inference we had to disable config precendence settings on non javascript files, this PR leverages from the fix on prettier 1.7.4 and bring back support to it.

Fixes: https://github.com/prettier/vim-prettier/issues/60