### PR TITLE
bugfix: Fixing auto command params to use extensions instead of magic

### DIFF
--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.css call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.graphql,*.gql call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.js,*.jsx,*.mjs call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.json call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.less call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/scss.vim
+++ b/ftplugin/scss.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.scss call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre <buffer> call prettier#Autoformat()
+    autocmd BufWritePre *.ts,*.tsx call prettier#Autoformat()
   endif
 augroup end


### PR DESCRIPTION
bugfix: Fixing auto command params to use file extensions instead of magic <buffer> variable