### PR TITLE
adding suppor for vim8 versions older than 8.0.0015 to use async job API

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -125,7 +125,7 @@ function! s:Prettier_Job_Close(channel, startSelection, endSelection, bufferName
   let l:currentBufferName = bufname('%')
   let l:isInsideAnotherBuffer = a:bufferName != l:currentBufferName ? 1 : 0
 
-  while ch_status(a:channel, {'part': 'out'}) == 'buffered'
+  while ch_status(a:channel) ==# 'buffered'
     call add(l:out, ch_read(a:channel))
   endwhile
 


### PR DESCRIPTION
Adding support for Vim versions older than 8.0-0015 

> My vim doesn't have patch-8.0-0015, which is when support for options was added to ch_status. Could we remove {'part': 'out'} from this line?

cc @alanhamlett 