### PR TITLE
Fixing bug where config was not being correctly loaded based on file

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -256,7 +256,7 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ ' --config-precedence ' .
           \ get(a:config, 'configPrecedence', g:prettier#config#config_precedence) .
           \ ' --stdin-filepath ' .
-          \ simplify(expand("%:t")) .
+          \ simplify(expand("%:p")) .
           \ ' --stdin '
   return l:cmd
 endfunction


### PR DESCRIPTION
We need to include the full path of the edited file to `--stdin-filepath` in order for `prettier` to correctly identify configuration file that is nearest to the edited file.

fixes: https://github.com/prettier/vim-prettier/issues/71