### PR TITLE
Issue 77/adding support for prettier 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,43 @@
 ## vim-prettier
 
-A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
+A vim plugin wrapper for prettier, pre-configured with custom default prettier
+settings.
 
-**Note:** requires `prettier` version 1.7.4+
+---
 
-***
-
-By default it will auto format **javascript**, **typescript**, **less**, **scss**, **css**, **json**, and **graphql** files that have "@format" annotation in the header of the file.
+By default it will auto format **javascript**, **typescript**, **less**,
+**scss**, **css**, **json**, **graphql** and **markdown** files if they
+have/support the "@format" pragma annotation in the header of the file.
 
 ![vim-prettier](/media/vim-prettier.gif?raw=true "vim-prettier")
 
 ### INSTALL
 
-Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes node and yarn|npm installed globally.
+Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes node and
+yarn|npm installed globally.
 
 ```vim
 " post install (yarn install | npm install) then load plugin only for editing supported files
 Plug 'prettier/vim-prettier', {
   \ 'do': 'yarn install',
-  \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql'] }
+  \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown'] }
 ```
 
-If using other vim plugin managers or doing manual setup make sure to have `prettier` installed globally or go to your vim-prettier directory and either do `npm install` or `yarn install`
+or simply enable for all formats by:
+
+```vim
+" post install (yarn install | npm install) then load plugin only for editing supported files
+Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
+```
+
+If using other vim plugin managers or doing manual setup make sure to have
+`prettier` installed globally or go to your vim-prettier directory and either do
+`npm install` or `yarn install`
 
 ### Prettier Executable resolution
 
-When installed via vim-plug, a default prettier executable is installed inside vim-prettier.
+When installed via vim-plug, a default prettier executable is installed inside
+vim-prettier.
 
 vim-prettier executable resolution:
 
@@ -54,7 +66,7 @@ If your are on vim 8+ you can also trigger async formatting by:
 :PrettierAsync
 ```
 
-You can check what is the `vim-prettier` plugin version by: 
+You can check what is the `vim-prettier` plugin version by:
 
 ```vim
 :PrettierVersion
@@ -72,7 +84,7 @@ You can check what is the resolved `prettier` cli path by:
 :PrettierCliPath
 ```
 
-You can check what is the resolved `prettier` cli version by: 
+You can check what is the resolved `prettier` cli version by:
 
 ```vim
 :PrettierCliVersion
@@ -117,14 +129,14 @@ Running before saving sync:
 
 ```vim
 let g:prettier#autoformat = 0
-autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql Prettier
+autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md Prettier
 ```
 
 Running before saving async (vim 8+):
 
 ```vim
 let g:prettier#autoformat = 0
-autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql PrettierAsync
+autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md PrettierAsync
 ```
 
 Running before saving, changing text or leaving insert mode:
@@ -134,12 +146,13 @@ Running before saving, changing text or leaving insert mode:
 let g:prettier#quickfix_enabled = 0
 
 let g:prettier#autoformat = 0
-autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql PrettierAsync
+autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md PrettierAsync
 ```
 
 ### Overwrite default prettier configuration
 
-**Note:** vim-prettier default settings differ from prettier intentionally. However they can be configured by:
+**Note:** vim-prettier default settings differ from prettier intentionally.
+However they can be configured by:
 
 ```vim
 " max line length that prettier will wrap on
@@ -166,7 +179,7 @@ g:prettier#config#jsx_bracket_same_line = 'true'
 " none|es5|all
 g:prettier#config#trailing_comma = 'all'
 
-" flow|babylon|typescript|postcss|json|graphql
+" flow|babylon|typescript|css|less|scss|json|graphql|markdown
 g:prettier#config#parser = 'flow'
 
 " cli-override|file-override|prefer-file

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -8,6 +8,7 @@ Author: Mitermayer Reis <mitermayer.reis@gmail.com>
 WebSite: https://prettier.io/
 Repository: https://github.com/prettier/vim-prettier
 License: MIT style license
+Version: 0.2.4
 
 ==============================================================================
 CONTENTS                                                *vim-prettier-contents*
@@ -23,8 +24,6 @@ INTRODUCTION                                        *vim-prettier-introduction*
 
 A vim plugin wrapper for prettier, pre-configured with 
 custom default prettier settings.
-
-**Note:** requires `prettier` version 1.7.0+
 
 By default it will auto format javascript, typescript, less, scss, css,
 json, and graphql files that have '@format' annotation in the header of the file.
@@ -45,10 +44,16 @@ INSTALL                                                  *vim-prettier-install*
 Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes 
 node and yarn|npm installed globally.
 >
-  Plug 'prettier/vim-prettier', { 
-	\ 'do': 'yarn install', 
-	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql'] } 
+  Plug 'prettier/vim-prettier', {
+	\ 'do': 'yarn install',
+	\ 'for': ['javascript', 'typescript', 'css',
+	\         'less', 'scss', 'json', 'graphql', 'markdown'] }
 <
+or simply enable for all formats by:
+>
+  Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
+<
+
 If using other vim plugin managers or doing manual setup make sure to have 
 `prettier` installed globally or go to your vim-prettier directory and 
 either do `npm install` or `yarn install` 
@@ -110,20 +115,19 @@ First disable the default autoformat, then update to your own custom behaviour
 Running before saving sync:
 >
   let g:prettier#autoformat = 0
-  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less,*.graphql Prettier
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md Prettier
 <
 Running before saving async (vim 8+):
 >
   let g:prettier#autoformat = 0
-  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less,*.graphql PrettierAsync
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md PrettierAsync
 <
 Running before saving, changing text or leaving insert mode: 
 >
-  let g:prettier#autoformat = 0
   " when running at every change you may want to disable quickfix
   let g:prettier#quickfix_enabled = 0
-
-  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less,*.graphql PrettierAsync
+  let g:prettier#autoformat = 0
+  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md PrettierAsync
 <
 Overwrite default prettier configuration
 
@@ -154,7 +158,7 @@ However they can be configured by:
   " none|es5|all
   g:prettier#config#trailing_comma = 'all'
 
-  " flow|babylon|typescript|postcss|json|graphql
+  " flow|babylon|typescript|css|less|scss|json|graphql|markdown
   g:prettier#config#parser = 'flow'
 
   " cli-override|file-override|prefer-file

--- a/ftdetect/markdown.vim
+++ b/ftdetect/markdown.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.markdown,*.md,*.mdown,*.mkd,*.mkdn setfiletype markdown

--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'css',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'graphql',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'json',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'less',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'markdown',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,0 +1,6 @@
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn call prettier#Autoformat()
+  endif
+augroup end

--- a/ftplugin/scss.vim
+++ b/ftplugin/scss.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'scss',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,3 +1,7 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'typescript',
+  \ }
+
 augroup Prettier
   autocmd!
   if g:prettier#autoformat

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "dependencies": {
-    "prettier": "^1.7.4"
+    "prettier": "^1.8.1"
   }
 }


### PR DESCRIPTION
Adds support for prettier 1.8

* Run `prettier` on README :)
* Pass the parsers explicitly to the configuration
* Bump internal plugin dependency
* Add support for markdown formatting
* Update readme and docs

fixes: https://github.com/prettier/vim-prettier/issues/77