### PR TITLE
issues-83-and-84 - Fixing prettier 1.9 regression

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -259,6 +259,8 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ get(a:config, 'configPrecedence', g:prettier#config#config_precedence) .
           \ ' --stdin-filepath ' .
           \ simplify(expand("%:p")) .
+          \ ' --no-editorconfig '.
+          \ ' --loglevel "error" '.
           \ ' --stdin '
   return l:cmd
 endfunction


### PR DESCRIPTION
- Latest prettier version introduced a regression when using
config-precedence
- https://github.com/prettier/prettier/issues/3432

fixes: https://github.com/prettier/vim-prettier/issues/84 and https://github.com/prettier/vim-prettier/issues/83