### PR TITLE
bugfix - making sure we do not replace content with empty buffer

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -222,6 +222,11 @@ function! s:Apply_Prettier_Format(lines, startSelection, endSelection) abort
   let l:winview = winsaveview()
   let l:newBuffer = s:Get_New_Buffer(a:lines, a:startSelection, a:endSelection)
 
+  " we should not replace contents if the newBuffer is empty
+  if empty(l:newBuffer)
+    return
+  endif
+
   " delete all lines on the current buffer
   silent! execute len(l:newBuffer) . ',' . line('$') . 'delete _'
 


### PR DESCRIPTION
Will come up with a more generic fix inside `prettier` itself but in the meantime making sure we do not replace contents with empty buffer fix the issue of `ignored` files been overwritten.

fixes: https://github.com/prettier/vim-prettier/issues/92

This issue (https://github.com/prettier/prettier/issues/3590) will track the fix inside prettier itself