### PR TITLE
Disabling nvim async by default under feature flag

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -55,7 +55,7 @@ function! prettier#Prettier(...) abort
 
     if l:async && v:version >= 800 && exists('*job_start')
       call s:Prettier_Exec_Async(l:cmd, l:startSelection, l:endSelection)
-    elseif l:async && has('nvim')
+    elseif l:async && has('nvim') && g:prettier#nvim_unstable_async
       call s:Prettier_Exec_Async_Nvim(l:cmd, l:startSelection, l:endSelection)
     else
       call s:Prettier_Exec_Sync(l:cmd, l:startSelection, l:endSelection)

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -20,6 +20,9 @@ let g:loaded_prettier = 1
 " autoformating enabled by default upon saving
 let g:prettier#autoformat = get(g:, 'prettier#autoformat', 1)
 
+" experimental async flag will be disabled by default until is stable
+let g:prettier#nvim_unstable_async = get(g:,'prettier#nvim_unstable_async', 0)
+
 " path to prettier cli
 let g:prettier#exec_cmd_path = get(g:, 'prettier#exec_cmd_path', 0)
 


### PR DESCRIPTION
- The new nvim async had some bugs reported, while we are still investigating fixes for it we will then disable it by default, users should be able to still use it by enabling the flag on their .vimrc in the meantime `g:prettier#nvim_unstable_async`

It's important for us to get the neovim integration working, but since there has been some bugs reported on it we need to make sure we mature it a bit more prior to removing the darkfeature flag, users that want to still use neovim async feature can enable it by adding the darkfeature flag  `g:prettier#nvim_unstable_async` to their `.vimrc`

fixes: 96