### PR TITLE
[WIP] feat($plugins): start the work on supporting custom plugins

### DIFF
--- a/ftdetect/php.vim
+++ b/ftdetect/php.vim
@@ -1,0 +1,2 @@
+autocmd BufNewFile,BufReadPost *.php setfiletype php
+

--- a/ftdetect/python.vim
+++ b/ftdetect/python.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.py setfiletype python

--- a/ftdetect/swift.vim
+++ b/ftdetect/swift.vim
@@ -1,0 +1,2 @@
+autocmd BufNewFile,BufReadPost *.swift setfiletype swift
+

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,0 +1,11 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'php',
+  \ }
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre *.php call prettier#Autoformat()
+  endif
+augroup end
+

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -1,0 +1,12 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'python',
+  \ }
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre *.py call prettier#Autoformat()
+  endif
+augroup end
+
+

--- a/ftplugin/swift.vim
+++ b/ftplugin/swift.vim
@@ -1,0 +1,12 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'swift',
+  \ }
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre *.swift call prettier#Autoformat()
+  endif
+augroup end
+
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "dependencies": {
+    "@prettier/plugin-php": "prettier/plugin-php",
+    "@prettier/plugin-python": "prettier/plugin-python",
+    "@prettier/plugin-swift": "prettier/plugin-swift",
     "prettier": "^1.10.2"
   }
 }


### PR DESCRIPTION
**Summary**

This PR implements the work described in #119. We start to depend on custom known plugins and provide config for them out of the box.

For now, this contains _almost_ everything that is needed for that to work, besides the `--plugins` flag passing to `prettier` binary. I'm not really sure how to approach that, because we need to gracefully fallback to a user-defined `.prettierrc` file.

**Test Plan**

1. Open a `*.php` ,`*.swift` or `*.py` file and run `:Prettier`