### PR TITLE
don't change focus to the quicklist

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -48,7 +48,7 @@ function! prettier#Prettier(...) abort
 
     " close quickfix if it is opened
     if s:prettier_quickfix_open
-      call setqflist([])
+      call setqflist([], 'r')
       cclose
       let s:prettier_quickfix_open = 0
     endif
@@ -248,8 +248,13 @@ function! s:Handle_Parsing_Errors(out) abort
   endfor
 
   if len(l:errors)
-    call setqflist(l:errors)
+    let l:winnr = winnr()
+    call setqflist(l:errors, 'r')
     botright copen
+    if !g:prettier#no_focus_quicklist
+      " Return the cursor back to the main buffer.
+      exe l:winnr . 'wincmd w'
+    endif
     let s:prettier_quickfix_open = 1
   endif
 endfunction

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -109,6 +109,11 @@ By default parsing errors will open the quickfix but can also be disabled
 >
   let g:prettier#exec_cmd_async = 1
 <
+Have the cursor returned to its original window after the quickfix window is
+shown.
+>
+  let g:prettier#no_focus_quicklist = 1
+<
 To enable vim-prettier to run in files without requiring the "@format" doc tag.
 First disable the default autoformat, then update to your own custom behaviour
 

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -69,6 +69,9 @@ let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_preced
 " always|never|preserve
 let g:prettier#config#prose_wrap = get(g:, 'prettier#config#prose_wrap', 'preserve')
 
+" Don't leave the quicklist focused on error.
+let g:prettier#no_focus_quicklist = get(g:, 'prettier#no_focus_quicklist', 0)
+
 " synchronous by default
 command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>)
 


### PR DESCRIPTION
By default setqflist focuses the quicklist, which is annoying.

This restores the cursor position after calling setqflist.