### PR TITLE
Start using prettier default arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,50 +168,31 @@ autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.
 However they can be configured by:
 
 ```vim
-" max line length that prettier will wrap on
-" Prettier default: 80
-let g:prettier#config#print_width = 80
+" Max line length that prettier will wrap on: a number or 'auto' (use
+" textwidth).
+" default: 'auto'
+let g:prettier#config#print_width = 'auto'
 
-" number of spaces per indentation level
-" Prettier default: 2
-let g:prettier#config#tab_width = 2
+" number of spaces per indentation level: a number or 'auto' (use
+" softtabstop)
+" default: 'auto'
+let g:prettier#config#tab_width = 'auto'
 
-" use tabs over spaces
-" Prettier default: false
-let g:prettier#config#use_tabs = 'false'
+" use tabs instead of spaces: true, false, or auto (use the expandtab setting).
+" default: 'auto'
+let g:prettier#config#use_tabs = 'auto'
 
-" print semicolons
-" Prettier default: true
-let g:prettier#config#semi = 'true'
-
-" single quotes over double quotes
-" Prettier default: false
-let g:prettier#config#single_quote = 'true'
-
-" print spaces between brackets
-" Prettier default: true
-let g:prettier#config#bracket_spacing = 'false'
-
-" put > on the last line instead of new line
-" Prettier default: false
-let g:prettier#config#jsx_bracket_same_line = 'true'
-
-" avoid|always
-" Prettier default: avoid
-let g:prettier#config#arrow_parens = 'always'
-
-" none|es5|all
-" Prettier default: none
-let g:prettier#config#trailing_comma = 'all'
-
-" flow|babylon|typescript|css|less|scss|json|graphql|markdown
-" Prettier default: babylon
-let g:prettier#config#parser = 'flow'
+" flow|babylon|typescript|css|less|scss|json|graphql|markdown or empty string
+" (let prettier choose).
+" default: ''
+let g:prettier#config#parser = ''
 
 " cli-override|file-override|prefer-file
-let g:prettier#config#config_precedence = 'prefer-file'
+" default: 'cli-override'
+let g:prettier#config#config_precedence = 'cli-override'
 
 " always|never|preserve
+" default: 'preserve'
 let g:prettier#config#prose_wrap = 'preserve'
 ```
 

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -138,40 +138,31 @@ Overwrite default prettier configuration
 **Note:** vim-prettier default settings differ from prettier intentionally. 
 However they can be configured by:
 >
-  " max line length that prettier will wrap on
-  let g:prettier#config#print_width = 80
+  " Max line length that prettier will wrap on: a number or 'auto' (use
+  " textwidth).
+  " default: 'auto'
+  let g:prettier#config#print_width = 'auto'
 
-  " number of spaces per indentation level
-  let g:prettier#config#tab_width = 2
+  " number of spaces per indentation level: a number or 'auto' (use
+  " softtabstop)
+  " default: 'auto'
+  let g:prettier#config#tab_width = 'auto'
 
-  " use tabs over spaces
-  let g:prettier#config#use_tabs = 'false'
+  " use tabs instead of spaces: true, false, or auto (use the expandtab setting).
+  " default: 'auto'
+  let g:prettier#config#use_tabs = 'auto'
 
-  " print semicolons
-  let g:prettier#config#semi = 'true'
-
-  " single quotes over double quotes
-  let g:prettier#config#single_quote = 'true' 
-
-  " print spaces between brackets
-  let g:prettier#config#bracket_spacing = 'false' 
-
-  " put > on the last line instead of new line
-  let g:prettier#config#jsx_bracket_same_line = 'true'
-
-  " avoid|always
-  let g:prettier#config#arrow_parens = 'always'
-
-  " none|es5|all
-  let g:prettier#config#trailing_comma = 'all'
-
-  " flow|babylon|typescript|css|less|scss|json|graphql|markdown
-  let g:prettier#config#parser = 'flow'
+  " flow|babylon|typescript|css|less|scss|json|graphql|markdown or empty string
+  " (let prettier choose).
+  " default: ''
+  let g:prettier#config#parser = ''
 
   " cli-override|file-override|prefer-file
-  let g:prettier#config#config_precedence = 'prefer-file'
+  " default: 'cli-override'
+  let g:prettier#config#config_precedence = 'cli-override'
 
   " always|never|preserve
+  " default: 'preserve'
   let g:prettier#config#prose_wrap = 'preserve'
 <
 ==============================================================================

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -33,40 +33,31 @@ let g:prettier#exec_cmd_async = get(g:, 'prettier#exec_cmd_async', 0)
 let g:prettier#quickfix_enabled = get(g:, 'prettier#quickfix_enabled', 1)
 
 " => Prettier CLI config
-" max line lengh that prettier will wrap on
-let g:prettier#config#print_width = get(g:, 'prettier#config#print_width', 80)
+" Max line length that prettier will wrap on: a number or 'auto' (use
+" textwidth).
+" default: 'auto'
+let g:prettier#config#print_width = get(g:, 'prettier#config#print_width', 'auto')
 
-" number of spaces per indentation level
-let g:prettier#config#tab_width = get(g:,'prettier#config#tab_width', 2)
+" number of spaces per indentation level: a number or 'auto' (use
+" softtabstop)
+" default: 'auto'
+let g:prettier#config#tab_width = get(g:,'prettier#config#tab_width', 'auto')
 
-" use tabs over spaces
-let g:prettier#config#use_tabs = get(g:,'prettier#config#use_tabs', 'false')
+" use tabs instead of spaces: true, false, or auto (use the expandtab setting).
+" default: 'auto'
+let g:prettier#config#use_tabs = get(g:,'prettier#config#use_tabs', 'auto')
 
-" print semicolons
-let g:prettier#config#semi = get(g:,'prettier#config#semi', 'true')
-
-" single quotes over double quotes
-let g:prettier#config#single_quote = get(g:,'prettier#config#single_quote', 'true')
-
-" print spaces between brackets
-let g:prettier#config#bracket_spacing = get(g:,'prettier#config#bracket_spacing', 'false')
-
-" put > on the last line instead of new line
-let g:prettier#config#jsx_bracket_same_line = get(g:,'prettier#config#jsx_bracket_same_line', 'true')
-
-" avoid wrapping a single arrow function param in parens
-let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'avoid')
-
-" none|es5|all
-let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'all')
-
-" flow|babylon|typescript|postcss|json|graphql
-let g:prettier#config#parser = get(g:,'prettier#config#parser', 'flow')
+" flow|babylon|typescript|css|less|scss|json|graphql|markdown or empty string
+" (let prettier choose).
+" default: ''
+let g:prettier#config#parser = get(g:,'prettier#config#parser', '')
 
 " cli-override|file-override|prefer-file
-let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_precedence', 'prefer-file')
+" default: 'cli-override'
+let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_precedence', 'cli-override')
 
 " always|never|preserve
+" default: 'preserve'
 let g:prettier#config#prose_wrap = get(g:, 'prettier#config#prose_wrap', 'preserve')
 
 " Don't leave the quicklist focused on error.


### PR DESCRIPTION
This is one approach for handling default prettier arguments.

I think ejecting the flags that the editor can't know the answers to (in favor of `.prettierrc` files) will help overall.

Especially since the flags for certain variations of prettier will be different. It's better to keep it simple.

Maybe we can add a generic `g:prettier#config#addition_cli_flags` and it's `b:` variant instead?