### PR TITLE
Fix PrettierAsync segmentation fault

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -285,7 +285,10 @@ function! s:Apply_Prettier_Format(lines, startSelection, endSelection) abort
     silent! call append(l:idx, l:line)
     let l:idx += 1
   endfor
-
+  
+  " delete trailing newline introduced by the above append procedure
+  silent! execute '$delete _'
+  
   " Restore view
   call winrestview(l:winview)
 endfunction

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -168,14 +168,13 @@ function! s:Prettier_Exec_Async(cmd, startSelection, endSelection) abort
 
   if s:prettier_job_running != 1
       let s:prettier_job_running = 1
-      call job_start([&shell, &shellcmdflag, l:async_cmd], {
-        \ 'in_io': 'buffer',
-        \ 'in_top': a:startSelection,
-        \ 'in_bot': a:endSelection,
-        \ 'in_name': l:bufferName,
+      let l:job =  job_start([&shell, &shellcmdflag, l:async_cmd], {
         \ 'err_cb': {channel, msg -> s:Prettier_Job_Error(msg)},
         \ 'close_cb': {channel -> s:Prettier_Job_Close(channel, a:startSelection, a:endSelection, l:bufferName)}})
-  endif
+      let l:stdin = job_getchannel(l:job)
+      call ch_sendraw(l:stdin, join(getbufline(bufnr(l:bufferName), a:startSelection,a:endSelection), "\n"))
+      call ch_close_in(l:stdin)
+    endif
 endfunction
 
 function! s:Prettier_Job_Close(channel, startSelection, endSelection, bufferName) abort
@@ -278,10 +277,14 @@ function! s:Apply_Prettier_Format(lines, startSelection, endSelection) abort
   endif
 
   " delete all lines on the current buffer
-  silent! execute len(l:newBuffer) . ',' . line('$') . 'delete _'
+  silent! execute '%delete _'
 
   " replace all lines from the current buffer with output from prettier
-  call setline(1, l:newBuffer)
+  let l:idx = 0
+  for l:line in l:newBuffer
+    silent! call append(l:idx, l:line)
+    let l:idx += 1
+  endfor
 
   " Restore view
   call winrestview(l:winview)


### PR DESCRIPTION
**Summary**

This pull request fixes #135 where the command `PrettierAsync` causes Vim to crash due to segmentation fault.

The following is a summary of the involved fixes:

*Transportation fix:*

1. Change the jobs `in_io` back to the default of `pipe`
2. Read the selected buffer lines and write them to the jobs channel
3. Close the in channel to tell the job we have finished sending

*Performance fix:*

1. Use a simpler method to delete all lines in the buffer
2. Loop through and append all the lines we want to write to the buffer

**Test Plan**

*Error Reproduction Steps:*

1. Copy the `crash.js` file from @nerfologist reproduction example - https://raw.githubusercontent.com/nerfologist/vim-prettier-async-segv-bug/master/crash.js
2. Open `crash.js` in vim
3. Execute `PrettierAsync`
4. Notice the seg fault!

**NOTE:** If the seg fault doesn't occur, increase the number of lines calling `someFunc('something', () => {});`. Eventually you will reach your platforms magic buffer size to cause the seg fault.

*Test Steps For Fix:*

1. Clone pull request commit
2. Copy the `crash.js` file from @nerfologist reproduction example - https://raw.githubusercontent.com/nerfologist/vim-prettier-async-segv-bug/master/crash.js
3. Open `crash.js` in vim
4. Execute `PrettierAsync`
5. Notice there is no seg fault!
6. Make the file much bigger and try again
7. Notice there is still no seg fault!

