### PR TITLE
Remove wrong comment on README.md comment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plug 'prettier/vim-prettier', {
 or simply enable for all formats by:
 
 ```vim
-" post install (yarn install | npm install) then load plugin only for editing supported files
+" post install (yarn install | npm install)
 Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
 ```
 


### PR DESCRIPTION

**Summary**

The example that shows how to enable `vim-prettier` for all files had a comment about only enabling it for supported files (looks like it was copy and pasted from the previous example).

**Test Plan**

Not needed