### PR TITLE
Fix PrettierAsync ignored file contents mangling

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -169,6 +169,7 @@ function! s:Prettier_Exec_Async(cmd, startSelection, endSelection) abort
   if s:prettier_job_running != 1
       let s:prettier_job_running = 1
       let l:job =  job_start([&shell, &shellcmdflag, l:async_cmd], {
+        \ 'out_io': 'buffer',
         \ 'err_cb': {channel, msg -> s:Prettier_Job_Error(msg)},
         \ 'close_cb': {channel -> s:Prettier_Job_Close(channel, a:startSelection, a:endSelection, l:bufferName)}})
       let l:stdin = job_getchannel(l:job)
@@ -182,9 +183,9 @@ function! s:Prettier_Job_Close(channel, startSelection, endSelection, bufferName
   let l:currentBufferName = bufname('%')
   let l:isInsideAnotherBuffer = a:bufferName != l:currentBufferName ? 1 : 0
 
-  while ch_status(a:channel) ==# 'buffered'
-    call add(l:out, ch_read(a:channel))
-  endwhile
+  let l:buff = ch_getbufnr(a:channel, 'out')
+  let l:out = getbufline(l:buff, 2, '$')
+  execute 'bd!' . l:buff
 
   " nothing to update
   if (s:Has_Content_Changed(l:out, a:startSelection, a:endSelection) == 0)

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -190,6 +190,7 @@ function! s:Prettier_Job_Close(channel, startSelection, endSelection, bufferName
   " nothing to update
   if (s:Has_Content_Changed(l:out, a:startSelection, a:endSelection) == 0)
     let s:prettier_job_running = 0
+    redraw!
     return
   endif
 


### PR DESCRIPTION

**Summary**
This pull request fixes #140 where the PrettierAsync command causes the buffer contents to become garbled if the file is ignored by prettier.

It was found to be an issue with more recent versions of prettier that echo the stdin[1] of ignored files back to stdout[2].

1. https://github.com/prettier/prettier/blob/fb74dc54c337b92e2be6dfffe147ab42143e4e48/src/cli/util.js#L313
2. https://github.com/prettier/prettier/blob/fb74dc54c337b92e2be6dfffe147ab42143e4e48/src/cli/util.js#L126

Unfortunately, Vim channels do not like this very much. Vim writes NUL bytes to Prettier's stdin to indicate line endings. However, Prettier is echoing them back and then Vim is having trouble reading them back from what it thinks is a string, leading to undefined behaviour.

> A String in Vim cannot contain NUL bytes.  To send or receive NUL bytes read or write from a buffer.  See |in_io-buffer| and |out_io-buffer|.

https://github.com/vim/vim/blob/master/runtime/doc/channel.txt#L407

The work around is to do what the vim documentation suggests and let the job write to a hidden buffer. This doesn't seem to be effected by the segmentation fault issue the input buffer was causing.

I also was having a weird rendering issue if the file contents had not changed. I added a `redraw!` to that code path and it fixed it. I am not sure if this issue was pre-existing.

**Test Plan**

0. Make sure you have the latest Prettier installed
1. Create a new directory
2. Create a file called `foo.js`
3. Create a `.prettierignore` file
4. Add `foo.js` to the `.prettierignore` file
5. Add several lines of text to the `foo.js` file
6. Save the `foo.js` file
7. Notice the file contents are not garbled on the last line