### PR TITLE
Enable the default editorconfig support again

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -326,7 +326,6 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ get(a:config, 'proseWrap', g:prettier#config#prose_wrap) .
           \ ' --stdin-filepath ' .
           \ simplify(expand('%:p')) .
-          \ ' --no-editorconfig '.
           \ ' --loglevel error '.
           \ ' --stdin '
   return l:cmd


### PR DESCRIPTION
Hi, **Summary**

Removed the hardcoded `--no-editorconfig` option. This enables editorsupport again.

**Test Plan**

Tested on nvim 0.3.0 and prettier 1.13.0 with JavaScript.

Closes #141 