### PR TITLE
Add YAML support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: python
+python:
+  - "3.6"
 dist: precise
 install: 
   - pip install vim-vint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 python:
   - "3.6"
-dist: precise
 install: 
   - pip install vim-vint
 script: 

--- a/ftdetect/yaml.vim
+++ b/ftdetect/yaml.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.yaml,*.yml setfiletype yaml

--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -1,0 +1,10 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'yaml',
+  \ }
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre *.yaml call prettier#Autoformat()
+  endif
+augroup end


### PR DESCRIPTION
**Summary**

This PR adds support for YAML files.
Previously calling `:Prettier` on YAML files would fail with the dreaded "Prettier: failed to parse buffer."

**Test Plan**

Edit any YAML file with the plugin installed. Do it without and with this PR applied and note the difference.
Did this with:
`VIM - Vi IMproved 8.1 (2018 May 17, compiled Jun  7 2018 11:02:45)
macOS version` and prettier 1.14.2.