### PR TITLE
space for --use-tabs

### DIFF
--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -62,7 +62,7 @@ function! s:Flag_use_tabs(config) abort
   endif
 
   if ( l:value ==# 'true' )
-    return '--use-tabs'
+    return ' --use-tabs'
   else
     return ''
   endif


### PR DESCRIPTION
Just for reference. Adds a small white space.