### PR TITLE
Set default "config_precendence" to "file-override"

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ let g:prettier#config#use_tabs = 'auto'
 let g:prettier#config#parser = ''
 
 " cli-override|file-override|prefer-file
-" default: 'prefer-file'
-let g:prettier#config#config_precedence = 'prefer-file'
+" default: 'file-override'
+let g:prettier#config#config_precedence = 'file-override'
 
 " always|never|preserve
 " default: 'preserve'

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -176,8 +176,8 @@ However they can be configured by:
   let g:prettier#config#parser = ''
 
   " cli-override|file-override|prefer-file
-  " default: 'prefer-file'
-  let g:prettier#config#config_precedence = 'prefer-file'
+  " default: 'file-override'
+  let g:prettier#config#config_precedence = 'file-override'
 
   " always|never|preserve
   " default: 'preserve'

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -60,8 +60,8 @@ let g:prettier#config#use_tabs = get(g:,'prettier#config#use_tabs', 'auto')
 let g:prettier#config#parser = get(g:,'prettier#config#parser', '')
 
 " cli-override|file-override|prefer-file
-" default: 'prefer-file'
-let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_precedence', 'prefer-file')
+" default: 'file-override'
+let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_precedence', 'file-override')
 
 " always|never|preserve
 " default: 'preserve'


### PR DESCRIPTION
If user have custom file type plugin that set "parser" option, calling
":Prettier" will return error "Prettier: failed to parse buffer".

This was caused by running prettier with CLI option "--parser X" with
"--config-precedence prefer_file" will cause prettier to ignore the
"parser" option.