### PR TITLE
Handle file paths with whitespace

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -324,9 +324,9 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ get(a:config, 'configPrecedence', g:prettier#config#config_precedence) .
           \ ' --prose-wrap ' .
           \ get(a:config, 'proseWrap', g:prettier#config#prose_wrap) .
-          \ ' --stdin-filepath ' .
+          \ ' --stdin-filepath "' .
           \ simplify(expand('%:p')) .
-          \ ' --loglevel error '.
+          \ '" --loglevel error '.
           \ ' --stdin '
   return l:cmd
 endfunction

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -325,8 +325,8 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ ' --prose-wrap ' .
           \ get(a:config, 'proseWrap', g:prettier#config#prose_wrap) .
           \ ' --stdin-filepath "' .
-          \ simplify(expand('%:p')) .
-          \ '" --loglevel error '.
+          \ simplify(expand('%:p')) . '"' .
+          \ ' --loglevel error '.
           \ ' --stdin '
   return l:cmd
 endfunction


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, do a sanity check on `vim8` and `neovim`
3. If you've changed APIs, update the README and documentation `./doc/prettier.txt`

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to vim-prettier

* * * 

**Summary**

Wrap the path used for `--stdin-filepath` in quotes. This allows prettier to work with files that have whitespace in their paths.

references #108

**Test Plan**

1. Edit a file in a location with whitespace in the path (e.g., `/Users/jason/Library/Mobile Documents/foo.md`).
2. Run `:Prettier`.
3. Verify that prettier runs without error.