### PR TITLE
Add option for html whitespace sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ let g:prettier#config#config_precedence = 'prefer-file'
 
 " always|never|preserve
 let g:prettier#config#prose_wrap = 'preserve'
+
+" css|strict|ignore
+let g:prettier#config#html_whitespace_sensitivity = 'css'
 ```
 
 ### REQUIREMENT(S)

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -324,6 +324,8 @@ function! s:Get_Prettier_Exec_Args(config) abort
           \ get(a:config, 'configPrecedence', g:prettier#config#config_precedence) .
           \ ' --prose-wrap ' .
           \ get(a:config, 'proseWrap', g:prettier#config#prose_wrap) .
+          \ ' --html-whitespace-sensitivity ' .
+          \ get(a:config, 'htmlWhitespaceSensitivity', g:prettier#config#html_whitespace_sensitivity) .
           \ ' --stdin-filepath ' .
           \ simplify(expand('%:p')) .
           \ ' --loglevel error '.

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -174,6 +174,9 @@ However they can be configured by:
 
   " always|never|preserve
   let g:prettier#config#prose_wrap = 'preserve'
+
+  " css|strict|ignore
+  let g:prettier#config#html_whitespace_sensitivity = 'css'
 <
 ==============================================================================
 REQUIREMENT(S)                                      *vim-prettier-requirements*

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -69,6 +69,9 @@ let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_preced
 " always|never|preserve
 let g:prettier#config#prose_wrap = get(g:, 'prettier#config#prose_wrap', 'preserve')
 
+" css|strict|ignore
+let g:prettier#config#html_whitespace_sensitivity = get(g:, 'prettier#config#html_whitespace_sensitivity', 'css')
+
 " Don't leave the quicklist focused on error.
 let g:prettier#quickfix_auto_focus = get(g:, 'prettier#quickfix_auto_focus', 1)
 


### PR DESCRIPTION
**Summary**

Per Prettier's [Blog Post](https://prettier.io/blog/2018/11/07/1.15.0.html) there is an option for prettier's
sensitivity to html whitespace. See blog post for more details.

This adds that option to vim-prettier and sets the default to the
prettier default.

**Test Plan**

This works on vim 8 and neovim.