### PR TITLE
Make markdown check more resilient

### DIFF
--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -1,6 +1,6 @@
 " markdown files run this as well
 " https://stackoverflow.com/questions/22839269/why-does-vim-default-markdown-ftplugin-source-html-ftplugins-is-there-any-ways
-if &ft !=~ 'markdown'
+if &ft !~# 'markdown'
   let b:prettier_ft_default_args = {
     \ 'parser': 'html',
     \ }

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -1,6 +1,6 @@
 " markdown files run this as well
 " https://stackoverflow.com/questions/22839269/why-does-vim-default-markdown-ftplugin-source-html-ftplugins-is-there-any-ways
-if &ft !=# 'markdown'
+if &ft !=~ 'markdown'
   let b:prettier_ft_default_args = {
     \ 'parser': 'html',
     \ }


### PR DESCRIPTION
**Summary**

Markdown check used to check for exact string `'markdown'` which was not robust for mdx files or similar, meaning the mangling referenced in issue #166 still applied to mdx. Now it just checks to see if the word "markdown" is in it, which is more resilient to this issue. Not sure if this is the best solution.