### PR TITLE
Ignore generated help tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 TODO
+doc/tags
 node_modules
 .yarn_lock
 yarn.lock


### PR DESCRIPTION
**Summary**

Ignore the generated help tags file if present in git repository. This helps keep `git status` clean when tracking plugins using git submodules.

**Test Plan**

Running `:helptags ALL` regenerates all help tags files. Confirm that `git status` doesn't show `doc/tags` as an untracked file.