### PR TITLE
updating-travis-to-use-docker - Moving to use vint from docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
   - docker pull mitermayer/vim-test-bed
 
 script: 
-  - docker run --rm -v $PWD:/testplugin -v $PWD/test:/home "mitermayer/vim-test-bed" vint .
+  - docker run --rm -v $PWD:/testplugin -v $PWD/test:/home "mitermayer/vim-test-bed" vint testplugin 


### PR DESCRIPTION
- Moving to use the docker image to run builds