### PR TITLE
Adding support for require-pragma and depracting previous naive implemenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ let g:prettier#config#prose_wrap = 'preserve'
 " css|strict|ignore
 " default: 'css'
 let g:prettier#config#html_whitespace_sensitivity = 'css'
+
+" false|true
+" default: 'false'
+let g:prettier#config#require_pragma = 'false'
 ```
 
 ### REQUIREMENT(S)

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -34,33 +34,9 @@ function! prettier#PrettierCli(user_input) abort
   endif
 endfunction
 
-" Allows @format pragma support
+" Allows @format and @prettier pragma support upon saving
 function! prettier#Autoformat(...) abort
-  let l:curPos = getpos('.')
-  let l:maxLineLookup = 50
-  let l:maxTimeLookupMs = 500
-  let l:pattern = '@format'
-  let l:search = @/
-  let l:winview = winsaveview()
-
-  " we need to move selection to the top before looking up to avoid
-  " scanning a very long file
-  call cursor(1, 1)
-
-  " Search starting at the start of the document
-  if search(l:pattern, 'n', l:maxLineLookup, l:maxTimeLookupMs) > 0
-    " autoformat async
-    call prettier#Prettier(1)
-  endif
-
-  " Restore the selection and if greater then before it defaults to end
-  call cursor(l:curPos[1], l:curPos[2])
-
-  " Restore view
-  call winrestview(l:winview)
-
-  " Restore search
-  let @/=l:search
+  call prettier#Prettier(1, 1, line('$'), 0, { 'requirePragma': 'true'})
 endfunction
 
 " Main prettier command
@@ -71,8 +47,11 @@ function! prettier#Prettier(...) abort
   let l:endSelection = a:0 > 2 ? a:3 : line('$')
   let l:hasSelection = a:0 > 2 ? 1 : 0
   let l:partialFormat = a:0 > 3 && a:4 ? a:4 : 0
-  let l:config = getbufvar(bufnr('%'), 'prettier_ft_default_args', {})
   let l:partialFormatEnabled = l:hasSelection && l:partialFormat
+
+  let l:overWrite = a:0 > 4 ? a:5 : {}
+  let l:bufferConfig = getbufvar(bufnr('%'), 'prettier_ft_default_args', {})
+  let l:config = extend(l:bufferConfig, l:overWrite)
 
   if l:execCmd != -1
     " TODO

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -28,6 +28,8 @@ function! prettier#resolver#config#resolve(config, hasSelection, start, end) abo
           \ ' --html-whitespace-sensitivity ' .
           \ get(a:config, 'htmlWhitespaceSensitivity', g:prettier#config#html_whitespace_sensitivity) .
           \ ' --stdin-filepath="'.simplify(expand('%:p')).'"' .
+          \ ' --require-pragma=' .
+          \ get(a:config, 'requirePragma', g:prettier#config#require_pragma) .
           \ ' --loglevel error '.
           \ ' --stdin '
   return l:cmd

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -185,6 +185,10 @@ However they can be configured by:
 
   " css|strict|ignore
   let g:prettier#config#html_whitespace_sensitivity = 'css'
+
+  " false|true
+  " default: 'false'
+  let g:prettier#config#require_pragma = 'false'
 <
 ==============================================================================
 REQUIREMENT(S)                                      *vim-prettier-requirements*

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -5,10 +5,3 @@ if &filetype !~# 'markdown'
     \ 'parser': 'html',
     \ }
 endif
-
-augroup Prettier
-  autocmd!
-  if g:prettier#autoformat
-    autocmd BufWritePre *.html call prettier#Autoformat()
-  endif
-augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -136,3 +136,10 @@ nnoremap <silent> <Plug>(PrettierVersion) :PrettierVersion<CR>
 nnoremap <silent> <Plug>(PrettierCli) :PrettierCli<CR>
 nnoremap <silent> <Plug>(PrettierCliVersion) :PrettierCliVersion<CR>
 nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html call prettier#Autoformat()
+  endif
+augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -97,6 +97,9 @@ let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'avo
 " default: 'none'
 let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'none')
 
+" restrict itself to only format files that contain a special comment @prettier or @format
+let g:prettier#config#require_pragma=  get(g:, 'prettier#config#require_pragma', 'false')
+
 " synchronous by default
 command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>, g:prettier#partial_format)
 


### PR DESCRIPTION
This diff adds support for `require-pragma` option

***

- Removes naive implementation of `require-pragma` in favour of `prettier` cli implementation. There should be no change of behaviour besides some performances improvements as we no longer scan through the file in search of pragma tags

- This diff also enables user to autoformat based on `@prettier` tag as well as `@format` as opposed to just `@format`