### PR TITLE
Issues/184 fixing undo step

### DIFF
--- a/autoload/prettier/job/async/neovim.vim
+++ b/autoload/prettier/job/async/neovim.vim
@@ -73,7 +73,7 @@ function! s:onExit(status, info, out, err) abort
       try
         silent exec 'sp '. escape(bufname(a:info.buf_nr), ' \')
         call nvim_buf_set_lines(a:info.buf_nr, a:info.start, a:info.end, 0, l:out)
-        write
+        noautocmd write
       catch
         call prettier#logging#error#log('PARSING_ERROR')
       finally
@@ -91,7 +91,7 @@ function! s:onExit(status, info, out, err) abort
       " TODO
       " we should be auto saving in order to work similar to vim8
     call nvim_buf_set_lines(a:info.buf_nr, a:info.start, a:info.end, 0, l:out)
-    write
+    noautocmd write
   endif
 
   let s:prettier_job_running = 0

--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -10,8 +10,8 @@ function! prettier#utils#buffer#replace(lines, startSelection, endSelection) abo
 
   " https://vim.fandom.com/wiki/Restore_the_cursor_position_after_undoing_text_change_made_by_a_script
   " create a fake change entry and merge with undo stack prior to do formating
-  normal ix
-  normal x
+  normal! ix
+  normal! x
   try | silent undojoin | catch | endtry
 
   " delete all lines on the current buffer

--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -8,6 +8,12 @@ function! prettier#utils#buffer#replace(lines, startSelection, endSelection) abo
     return
   endif
 
+  " https://vim.fandom.com/wiki/Restore_the_cursor_position_after_undoing_text_change_made_by_a_script
+  " create a fake change entry and merge with undo stack prior to do formating
+  normal ix
+  normal x
+  try | silent undojoin | catch | endtry
+
   " delete all lines on the current buffer
   silent! execute '%delete _'
 
@@ -23,6 +29,7 @@ function! prettier#utils#buffer#replace(lines, startSelection, endSelection) abo
 
   " Restore view
   call winrestview(l:winview)
+
 endfunction
 
 " Replace and save the buffer

--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -28,7 +28,7 @@ endfunction
 " Replace and save the buffer
 function! prettier#utils#buffer#replaceAndSave(lines, startSelection, endSelection) abort
   call prettier#utils#buffer#replace(a:lines, a:startSelection, a:endSelection)
-  write
+  noautocmd write
 endfunction
 
 " Returns 1 if content has changed

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -140,6 +140,6 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 augroup Prettier
   autocmd!
   if g:prettier#autoformat
-    autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html call prettier#Autoformat()
+    autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html noautocmd | call prettier#Autoformat()
   endif
 augroup end


### PR DESCRIPTION
This PR fixes the undo jump of cursor after formatting.

In order to properly fix the cursor issue we have to do some other minor fixes:

- ensure that autosave does not trigger commands
- ensure that write does not trigger commands
- create a unmodified change and merge to undo stack prior to formatting

fixes: https://github.com/prettier/vim-prettier/issues/184