### PR TITLE
making-auto-format-disabled-by-default - Making autoformat disabled by

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default it will auto format **javascript**, **typescript**, **less**,
 **scss**, **css**, **json**, **graphql** and **markdown** files if they
 have/support the "@format" pragma annotation in the header of the file.
 
-![vim-prettier](/media/vim-prettier.gif?raw=true 'vim-prettier')
+![vim-prettier](/media/vim-prettier.gif?raw=true "vim-prettier")
 
 ### INSTALL
 
@@ -127,10 +127,10 @@ Change the mapping to run from the default of `<Leader>p`
 nmap <Leader>py <Plug>(Prettier)
 ```
 
-Disable auto formatting of files that have "@format" tag
+Enable auto formatting of files that have "@format" or "@prettier" tag
 
 ```vim
-let g:prettier#autoformat = 0
+let g:prettier#autoformat = 1
 ```
 
 Set the prettier CLI executable path
@@ -164,20 +164,18 @@ By default we auto focus on the quickfix when there are errors but can also be d
 let g:prettier#quickfix_auto_focus = 0
 ```
 
-To enable vim-prettier to run in files without requiring the "@format" doc tag.
-First disable the default autoformat, then update to your own custom behaviour
+To enable vim-prettier to auto run in files without requiring the "@format" or "@prettier" doc tag.
+First ensure that `g:prettier#autoformat` is not enabled on your `vimrc` (it should be disabled by default), then update to your own custom behaviour
 
 Running before saving sync:
 
 ```vim
-let g:prettier#autoformat = 0
 autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html Prettier
 ```
 
 Running before saving async (vim 8+):
 
 ```vim
-let g:prettier#autoformat = 0
 autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
 ```
 
@@ -187,7 +185,6 @@ Running before saving, changing text or leaving insert mode:
 " when running at every change you may want to disable quickfix
 let g:prettier#quickfix_enabled = 0
 
-let g:prettier#autoformat = 0
 autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
 ```
 

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -111,9 +111,9 @@ to prettier, this allows for faster formatting but wont preserve indentation.
 ==============================================================================
 CONFIGURATION                                       *vim-prettier-configuration*
 
-Disable auto formatting of files that have "@format" tag 
+Enable auto formatting of files that have "@format" or "@prettier" tag
 >
-  let g:prettier#autoformat = 0
+  let g:prettier#autoformat = 1
 <
 Set the prettier CLI executable path
 >
@@ -131,24 +131,21 @@ By default we auto focus on the quickfix when there are errors but can also be d
 >
   let g:prettier#quickfix_auto_focus = 0
 <
-To enable vim-prettier to run in files without requiring the "@format" doc tag.
-First disable the default autoformat, then update to your own custom behaviour
+To enable vim-prettier to auto run in files without requiring the "@format" or "@prettier" doc tag.
+First ensure that `g:prettier#autoformat` is not enabled on your `vimrc` (it should be disabled by default), then update to your own custom behaviour
 
 Running before saving sync:
 >
-  let g:prettier#autoformat = 0
   autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html Prettier
 <
 Running before saving async (vim 8+):
 >
-  let g:prettier#autoformat = 0
   autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
 <
 Running before saving, changing text or leaving insert mode: 
 >
   " when running at every change you may want to disable quickfix
   let g:prettier#quickfix_enabled = 0
-  let g:prettier#autoformat = 0
   autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
 <
 Overwrite default prettier configuration

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -18,7 +18,7 @@ let g:loaded_prettier = 1
 
 " => Plugin config
 " autoformating enabled by default upon saving
-let g:prettier#autoformat = get(g:, 'prettier#autoformat', 1)
+let g:prettier#autoformat = get(g:, 'prettier#autoformat', 0)
 
 " path to prettier cli
 let g:prettier#exec_cmd_path = get(g:, 'prettier#exec_cmd_path', 0)

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -17,7 +17,7 @@ endif
 let g:loaded_prettier = 1
 
 " => Plugin config
-" autoformating enabled by default upon saving
+" autoformating disabled by default upon saving
 let g:prettier#autoformat = get(g:, 'prettier#autoformat', 0)
 
 " path to prettier cli


### PR DESCRIPTION
### making-auto-format-disabled-by-default - Making autoformat disabled by                                                   default                                                                                                                    
                                                                                                                               
- This is a breaking change as on version `0.x` `autoformat` was enabled by                                                   
    default. 
+ This should ensure users dont need to disable autoformat                                                          
    anymore in their vimrc     