### PR TITLE
Toggle the autoformat setting based on config file presence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Enable auto formatting of files that have "@format" or "@prettier" tag
 let g:prettier#autoformat = 1
 ```
 
-Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory.
+Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory.  Note that this will override the `g:prettier#autoformat` setting!
 
 ```vim
 let g:prettier#autoformat_config_present = 1

--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ Enable auto formatting of files that have "@format" or "@prettier" tag
 let g:prettier#autoformat = 1
 ```
 
+Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory.
+
+```vim
+let g:prettier#autoformat_config_present = 1
+```
+
+A list containing all config file names to search for when using the `g:prettier#autoformat_config_present` option.
+
+```vim
+let g:prettier#autoformat_config_files = [...]
+```
+
 Set the prettier CLI executable path
 
 ```vim

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -78,3 +78,13 @@ function! prettier#Prettier(...) abort
     call prettier#logging#error#log('EXECUTABLE_NOT_FOUND_ERROR')
   endif
 endfunction
+
+" Set autoformat toggle based on whether config file was found.
+function! prettier#IsConfigPresent(config_files)
+  for config_file in a:config_files
+    if filereadable(findfile(config_file, '.;'))
+      return 1
+    endif
+  endfor
+  return 0
+endfunction

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -80,7 +80,7 @@ function! prettier#Prettier(...) abort
 endfunction
 
 " Set autoformat toggle based on whether config file was found.
-function! prettier#IsConfigPresent(config_files)
+function! prettier#IsConfigPresent(config_files) abort
   for config_file in a:config_files
     if filereadable(findfile(config_file, '.;'))
       return 1

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -114,6 +114,16 @@ CONFIGURATION                                       *vim-prettier-configuration*
 Enable auto formatting of files that have "@format" or "@prettier" tag
 >
   let g:prettier#autoformat = 1
+
+Enable auto formatting of files based on whether a Prettier configuration file has been
+found in the project directory or any parent directories.
+>
+  let g:prettier#autoformat_config_present = 1
+
+Configuration file names to search for when attempting to find an appropriate
+Prettier configuration file for the current project.
+>
+  let g:prettier#autoformat_config_files = [...]
 <
 Set the prettier CLI executable path
 >

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -20,6 +20,19 @@ let g:loaded_prettier = 1
 " autoformating disabled by default upon saving
 let g:prettier#autoformat = get(g:, 'prettier#autoformat', 0)
 
+" whether to turn autoformatting on if a prettier config file is found
+let g:prettier#autoformat_config_present = get(g:, 'prettier#autoformat_config_present', 0)
+
+" prettier config files to search current directory and parent directories for
+let g:prettier#autoformat_config_files = get(g:, 'prettier#autoformat_config_files', [
+      \'.prettierrc',
+      \'.prettierrc.yml',
+      \'.prettierrc.yaml',
+      \'.prettierrc.js',
+      \'.prettierrc.config.js',
+      \'.prettierrc.json'
+      \'.prettierrc.toml'])
+
 " path to prettier cli
 let g:prettier#exec_cmd_path = get(g:, 'prettier#exec_cmd_path', 0)
 
@@ -139,6 +152,14 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 
 augroup Prettier
   autocmd!
+  if g:prettier#autoformat_config_present
+    if prettier#IsConfigPresent(g:prettier#autoformat_config_files)
+      let g:prettier#autoformat = 1
+    else
+      let g:prettier#autoformat = 0
+    endif
+  endif
+
   if g:prettier#autoformat
     autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html noautocmd | call prettier#Autoformat()
   endif


### PR DESCRIPTION
# Summary
This PR will automatically toggle auto-formatting (i.e. format on save, `prettier#autoformat`) if a Prettier config file is found in the current directory or any parent directories.

# Test Plan
`.vimrc` used for testing:
```viml
call plug#begin()
Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
call plug#end()

let g:prettier#autoformat_config_present = 1
let g:prettier#config#config_precedence = 'prefer-file'
```

# Caveats
- [ ] This PR is based on the `release` branch instead of `master`.  I have not been able to get this to work on `master` yet.  Depending on when the next release occurs, it may make the most sense to simply wait until then and rebase this PR onto it.
- [x] Update `prettier.txt`
- [x] Update `README.md`
