### PR TITLE
Use `get()` to check `g:prettier#autoformat` safely in ftplugin

### DIFF
--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.css call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.graphql,*.gql call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -8,7 +8,7 @@ endif
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.html call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,6 +1,6 @@
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.js,*.jsx,*.mjs call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.json call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.less call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/scss.vim
+++ b/ftplugin/scss.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.scss call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.ts,*.tsx call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.vue call prettier#Autoformat()
   endif
 augroup end

--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -4,7 +4,7 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat
+  if get(g:, 'prettier#autoformat')
     autocmd BufWritePre *.yaml call prettier#Autoformat()
   endif
 augroup end


### PR DESCRIPTION
Due to the fact that `plugin` will be loaded after `ftplugin`(http://vimdoc.sourceforge.net/htmldoc/filetype.html#ftplugin-overrule),
even we set `g:prettier#autoformat` in plugin/prettier.vim, it's treated as undefined in ftplugin/*.vim.

This happened when using `vim-pathogen`.