### PR TITLE
New option: prettier#autoformat_require_pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Enable auto formatting of files that have "@format" or "@prettier" tag
 let g:prettier#autoformat = 1
 ```
 
+Allow auto formatting for files without "@format" or "@prettier" tag
+
+```vim
+let g:prettier#autoformat_require_pragma = 0
+```
+
 Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory. Note that this will override the `g:prettier#autoformat` setting!
 
 ```vim
@@ -181,28 +187,13 @@ By default we auto focus on the quickfix when there are errors but can also be d
 let g:prettier#quickfix_auto_focus = 0
 ```
 
-To enable vim-prettier to auto run in files without requiring the "@format" or "@prettier" doc tag.
-First ensure that `g:prettier#autoformat` is not enabled on your `vimrc` (it should be disabled by default), then update to your own custom behaviour
-
-Running before saving sync:
-
-```vim
-autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html Prettier
-```
-
-Running before saving async (vim 8+):
-
-```vim
-autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
-```
-
-Running before saving, changing text or leaving insert mode:
+To running vim-prettier not only before saving, but also after changing text or leaving insert mode:
 
 ```vim
 " when running at every change you may want to disable quickfix
 let g:prettier#quickfix_enabled = 0
 
-autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
+autocmd TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html PrettierAsync
 ```
 
 ### Overwrite default prettier configuration

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -36,7 +36,9 @@ endfunction
 
 " Allows @format and @prettier pragma support upon saving
 function! prettier#Autoformat(...) abort
-  call prettier#Prettier(1, 1, line('$'), 0, { 'requirePragma': 'true'})
+  call prettier#Prettier(1, 1, line('$'), 0, {
+    \ 'requirePragma': g:prettier#autoformat_require_pragma ? 'true' : 'false'
+    \ })
 endfunction
 
 " Main prettier command

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -20,6 +20,9 @@ let g:loaded_prettier = 1
 " autoformating disabled by default upon saving
 let g:prettier#autoformat = get(g:, 'prettier#autoformat', 0)
 
+" autoformating requires pragma by default
+let g:prettier#autoformat_require_pragma = get(g:, 'prettier#autoformat_require_pragma', 1)
+
 " whether to turn autoformatting on if a prettier config file is found
 let g:prettier#autoformat_config_present = get(g:, 'prettier#autoformat_config_present', 0)
 


### PR DESCRIPTION
**Summary**

The `prettier#autoformat_config_present` option is useful but it only worked with files with pragma. Now, you can use `autoformat_config_present` even with files without pragma using this `autoformat_require_pragma` option.

**Test Plan**

Not sure