### PR TITLE
Force reevaluation of autoformat settings at buffer write time

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -36,9 +36,15 @@ endfunction
 
 " Allows @format and @prettier pragma support upon saving
 function! prettier#Autoformat(...) abort
-  call prettier#Prettier(1, 1, line('$'), 0, {
-    \ 'requirePragma': g:prettier#autoformat_require_pragma ? 'true' : 'false'
-    \ })
+  let l:autoformat = g:prettier#autoformat_config_present ?
+        \ prettier#IsConfigPresent(g:prettier#autoformat_config_files) :
+        \ g:prettier#autoformat
+
+  if l:autoformat
+    call prettier#Prettier(1, 1, line('$'), 0, {
+      \ 'requirePragma': g:prettier#autoformat_require_pragma ? 'true' : 'false'
+      \ })
+  endif
 endfunction
 
 " Main prettier command

--- a/ftplugin/css.vim
+++ b/ftplugin/css.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.css call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.css call prettier#Autoformat()
 augroup end

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.graphql,*.gql call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.graphql,*.gql call prettier#Autoformat()
 augroup end

--- a/ftplugin/html.vim
+++ b/ftplugin/html.vim
@@ -8,7 +8,5 @@ endif
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.html call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.html call prettier#Autoformat()
 augroup end

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,6 +1,4 @@
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.js,*.jsx,*.mjs call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.js,*.jsx,*.mjs call prettier#Autoformat()
 augroup end

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.json call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.json call prettier#Autoformat()
 augroup end

--- a/ftplugin/less.vim
+++ b/ftplugin/less.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.less call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.less call prettier#Autoformat()
 augroup end

--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.lua call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.lua call prettier#Autoformat()
 augroup end

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn call prettier#Autoformat()
 augroup end

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.php call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.php call prettier#Autoformat()
 augroup end

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.ruby call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.ruby call prettier#Autoformat()
 augroup end

--- a/ftplugin/scss.vim
+++ b/ftplugin/scss.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.scss call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.scss call prettier#Autoformat()
 augroup end

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.ts,*.tsx call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.ts,*.tsx call prettier#Autoformat()
 augroup end

--- a/ftplugin/vue.vim
+++ b/ftplugin/vue.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.vue call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.vue call prettier#Autoformat()
 augroup end

--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -8,7 +8,5 @@ endif
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.xml call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.xml call prettier#Autoformat()
 augroup end

--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -4,7 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  if get(g:, 'prettier#autoformat')
-    autocmd BufWritePre *.yaml call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.yaml call prettier#Autoformat()
 augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -155,15 +155,5 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 
 augroup Prettier
   autocmd!
-  if g:prettier#autoformat_config_present
-    if prettier#IsConfigPresent(g:prettier#autoformat_config_files)
-      let g:prettier#autoformat = 1
-    else
-      let g:prettier#autoformat = 0
-    endif
-  endif
-
-  if g:prettier#autoformat
-    autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html noautocmd | call prettier#Autoformat()
-  endif
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html noautocmd | call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
**Summary**

Fixes #233

**Test Plan**

Regression tests:

* If `g:prettier#autoformat == 1` and `g:prettier#autoformat_config_present == 0`, ensure that `prettier` runs on buffer save, regardless of whether or not a config file is present.
* If `g:prettier#autoformat_config_present == 1`, ensure that `prettier` runs on buffer save if and only if a config file is present.

Tests for new behavior:

* Test for both bugs originally reported in #233 