### PR TITLE
Autoformat .rb files

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -4,5 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.ruby call prettier#Autoformat()
+  autocmd BufWritePre *.rb,*.ruby call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
*Before* submitting a pull request, please make sure the following is done...

1. Fork the repo and create your branch from `master`.
2. If you've added code that should be tested, do a sanity check on `vim8` and `neovim`
3. If you've changed APIs, update the README and documentation `./doc/prettier.txt`

Please use the simple form below as a guideline for describing your pull request.

Thanks for contributing to vim-prettier

* * * 

**Summary**

This adds `.rb` as an extension in `ftplugin/ruby.vim`, fixing a problem where ruby
files with a `.rb` extension were not being autoformatted.

**Test Plan**

I tested this locally by confirming that it now autoformats `.rb` files.
