### PR TITLE
issue/232-adding-support-for-prettier-2.x - Adding support for prettier 2x

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ let g:prettier#config#html_whitespace_sensitivity = 'css'
 " false|true
 " default: 'false'
 let g:prettier#config#require_pragma = 'false'
+
+" Define the flavor of line endings
+" lf|crlf|cr|all
+" defaut: 'lf'
+let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
 ```
 
 ### REQUIREMENT(S)

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -30,8 +30,11 @@ function! prettier#resolver#config#resolve(config, hasSelection, start, end) abo
           \ ' --stdin-filepath="'.simplify(expand('%:p')).'"' .
           \ ' --require-pragma=' .
           \ get(a:config, 'requirePragma', g:prettier#config#require_pragma) .
+          \ ' --end-of-line=' .
+          \ get(a:config, 'endOfLine', g:prettier#config#end_of_line) .
           \ ' --loglevel error '.
           \ ' --stdin '
+
   return l:cmd
 endfunction
 

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -195,8 +195,13 @@ However they can be configured by:
 
   " false|true
   " default: 'false'
-  let g:prettier#config#require_pragma = 'false'
-<
+  " let g:prettier#config#require_pragma = 'false'
+
+  " Define the flavor of line endings
+  " lf|crlf|cr|all
+  " defaut: 'lf' 
+  let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
+
 ==============================================================================
 REQUIREMENT(S)                                      *vim-prettier-requirements*
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@prettier/plugin-php": "^0.10.2",
     "@prettier/plugin-ruby": "^0.8.0",
     "@prettier/plugin-xml": "^0.7.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.4"
   },
   "devDependencies": {
     "colors": "^1.3.2",

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -105,16 +105,21 @@ let g:prettier#config#jsx_bracket_same_line = get(g:,'prettier#config#jsx_bracke
 
 " avoid wrapping a single arrow function param in parens
 " avoid|always
-" default: 'avoid'
-let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'avoid')
+" default: 'always'
+let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'always')
 
 " Print trailing commas wherever possible when multi-line.
 " none|es5|all
-" default: 'none'
-let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'none')
+" default: 'es5'
+let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'es5')
+
+" Define the flavor of line endings
+" lf|crlf|cr|all
+" defaut: 'lf' 
+let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
 
 " restrict itself to only format files that contain a special comment @prettier or @format
-let g:prettier#config#require_pragma=  get(g:, 'prettier#config#require_pragma', 'false')
+let g:prettier#config#require_pragma = get(g:, 'prettier#config#require_pragma', 'false')
 
 " synchronous by default
 command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>, g:prettier#partial_format)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,10 +2658,15 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@>=1.10, prettier@^1.16.4, prettier@^1.19.1:
+prettier@>=1.10, prettier@^1.16.4:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.4:
+  version "2.0.4"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
+  integrity sha1-LRuuFz41WZbuNV7Jgwp6HuBUV+8=
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
Adding support for prettier 2.x

- Updates prettier default configuration
- Include "classic" preset for older configurations
- Bump package.json and yarn.lock dependencies
- Include missing configuration
- Bump prettier plugin dependencies 

***

Fixes: https://github.com/prettier/vim-prettier/issues/232
