### PR TITLE
Fix string concatenation typo

### DIFF
--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -33,7 +33,7 @@ let g:prettier#autoformat_config_files = get(g:, 'prettier#autoformat_config_fil
       \'.prettierrc.yaml',
       \'.prettierrc.js',
       \'.prettierrc.config.js',
-      \'.prettierrc.json'
+      \'.prettierrc.json',
       \'.prettierrc.toml'])
 
 " path to prettier cli


### PR DESCRIPTION
**Summary**

I was wondering why `g:prettier#autoformat_config_present = 1` wasn't working correctly; this is it.
