### PR TITLE
Add missing ".yml" in autocmd

### DIFF
--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -4,5 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.yaml call prettier#Autoformat()
+  autocmd BufWritePre *.yml,*.yaml call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
**Summary**
Closes #245
The `autocmd` for `yaml` files miss the ".yml" extension
