### PR TITLE
Run autoformat for *.yml files too

### DIFF
--- a/ftplugin/yaml.vim
+++ b/ftplugin/yaml.vim
@@ -4,5 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.yaml call prettier#Autoformat()
+  autocmd BufWritePre *.yaml,*.yml call prettier#Autoformat()
 augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -114,7 +114,7 @@ let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'avo
 let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'none')
 
 " restrict itself to only format files that contain a special comment @prettier or @format
-let g:prettier#config#require_pragma=  get(g:, 'prettier#config#require_pragma', 'false')
+let g:prettier#config#require_pragma =  get(g:, 'prettier#config#require_pragma', 'false')
 
 " synchronous by default
 command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>, g:prettier#partial_format)
@@ -155,5 +155,5 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html noautocmd | call prettier#Autoformat()
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.yml,*.html noautocmd | call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
**Summary**

`autoload` configs for YAML files only consider the `.yaml` extension,
which makes the plugin ignore autoformat-on-save settings on `.yml`
files. As the latter is a very common format, I thought of including
that to the list.

**Test Plan**

Tested this out in my local copy on both `yaml` and `yml` files. Ran
`yarn run tests`, and they pass.