### PR TITLE
Fix error when quitting Neovim with :wq

### DIFF
--- a/autoload/prettier/job/async/neovim.vim
+++ b/autoload/prettier/job/async/neovim.vim
@@ -42,6 +42,8 @@ endfunction
 "
 "  note that somehow we exectuing both async and sync on nvim when using the autoformat
 function! s:onExit(status, info, out, err) abort
+  if len(a:out) == 0 | return | endif
+
   let l:currentBufferNumber =  bufnr('%')
   let l:isInsideAnotherBuffer = a:info.buf_nr != l:currentBufferNumber ? 1 : 0
   let l:last = a:out[len(a:out) - 1]


### PR DESCRIPTION
**Summary**

This fixes #215 by implementing the fix I've suggested in [my comment][0].

After [the suggestion to open a PR][1], here we are :)

[0]: https://github.com/prettier/vim-prettier/issues/215#issuecomment-629681399
[1]: https://github.com/prettier/vim-prettier/issues/215#issuecomment-648657236

**Test Plan**

Tested locally with nvim and fix has been confirmed by others in #215 to work.
