### PR TITLE
Add support for buffer-level prettier_exec_cmd, for prettier-stylelint for instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ vim-prettier executable resolution:
 3.  Look for a global prettier installation
 4.  Use locally installed vim-prettier prettier executable
 
+### Prettier Stylelint
+
+To use an alternative command, like
+[`prettier-stylelint`](https://github.com/hugomrdias/prettier-stylelint), set
+this at the buffer level, e.g.:
+
+```vim
+au FileType css,scss,scss.css let b:prettier_exec_cmd = "prettier-stylelint"
+```
+
+vim-prettier will look for the executable in the same places it looks for
+`prettier`, and will fall back to `prettier` if it can't find
+`b:prettier_exec_cmd`
+
 ### USAGE
 
 Prettier by default will run on auto save but can also be manually triggered by:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To use an alternative command, like
 this at the buffer level, e.g.:
 
 ```vim
-au FileType css,scss,scss.css let b:prettier_exec_cmd = "prettier-stylelint"
+au FileType css,scss let b:prettier_exec_cmd = "prettier-stylelint"
 ```
 
 vim-prettier will look for the executable in the same places it looks for

--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -33,7 +33,12 @@ endfunction
 function! s:GetExecPath(...) abort
   let l:rootDir = a:0 > 0 ? a:1 : -1
   let l:dir = l:rootDir != -1 ? l:rootDir . '/.bin/' : ''
-  return l:dir . 'prettier'
+  let l:path = l:dir . get(b:, 'prettier_exec_cmd', 'prettier')
+  if executable(l:path)
+    return l:path
+  else
+    return l:dir . 'prettier'
+  endif
 endfunction
 
 " Searches for the existence of a directory accross 


### PR DESCRIPTION
**Summary**

Add the ability to set a buffer-level `b:prettier_exec_cmd` for different prettier commands between buffers. This allows the user, for instance, to use `prettier-stylelint` for CSS files if desired.

**Test Plan**

Not sure exactly how to test this, looking for advice.

---

Closes #255 