### PR TITLE
Uses default cli configs

### DIFF
--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -105,13 +105,13 @@ let g:prettier#config#jsx_bracket_same_line = get(g:,'prettier#config#jsx_bracke
 
 " avoid wrapping a single arrow function param in parens
 " avoid|always
-" default: 'avoid'
-let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'avoid')
+" default: 'always'
+let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'always')
 
 " Print trailing commas wherever possible when multi-line.
 " none|es5|all
-" default: 'none'
-let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'none')
+" default: 'es5'
+let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'es5')
 
 " restrict itself to only format files that contain a special comment @prettier or @format
 let g:prettier#config#require_pragma=  get(g:, 'prettier#config#require_pragma', 'false')

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -59,61 +59,75 @@ let g:prettier#preset#config = get(g:,'prettier#preset#config', 'default')
 " Max line length that prettier will wrap on: a number or 'auto' (use
 " textwidth).
 " default: 'auto'
+" See more: https://prettier.io/docs/en/options.html#print-width
 let g:prettier#config#print_width = get(g:, 'prettier#config#print_width', 'auto')
 
 " number of spaces per indentation level: a number or 'auto' (use
 " softtabstop)
 " default: 'auto'
+" See more: https://prettier.io/docs/en/options.html#tab-width
 let g:prettier#config#tab_width = get(g:,'prettier#config#tab_width', 'auto')
 
 " use tabs instead of spaces: true, false, or auto (use the expandtab setting).
 " default: 'auto'
+" See more: https://prettier.io/docs/en/options.html#tabs
 let g:prettier#config#use_tabs = get(g:,'prettier#config#use_tabs', 'auto')
 
 " flow|babylon|typescript|css|less|scss|json|graphql|markdown or empty string
 " (let prettier choose).
 " default: ''
+" See more: https://prettier.io/docs/en/options.html#parser
 let g:prettier#config#parser = get(g:,'prettier#config#parser', '')
 
 " cli-override|file-override|prefer-file
 " default: 'file-override'
+" See more: https://prettier.io/docs/en/cli.html#--config-precedence
 let g:prettier#config#config_precedence = get(g:, 'prettier#config#config_precedence', 'file-override')
 
 " always|never|preserve
 " default: 'preserve'
+" See more: https://prettier.io/docs/en/options.html#prose-wrap
 let g:prettier#config#prose_wrap = get(g:, 'prettier#config#prose_wrap', 'preserve')
 
 " css|strict|ignore
 " default: 'css'
+" See more: https://prettier.io/docs/en/options.html#html-whitespace-sensitivity
 let g:prettier#config#html_whitespace_sensitivity = get(g:, 'prettier#config#html_whitespace_sensitivity', 'css')
 
 " print semicolons
 " default: 'true'
+" See more: https://prettier.io/docs/en/options.html#semicolons
 let g:prettier#config#semi = get(g:,'prettier#config#semi', 'true')
 
 " Use single quotes instead of double quotes.
 " default: 'false'
+" See more: https://prettier.io/docs/en/options.html#quotes
 let g:prettier#config#single_quote = get(g:,'prettier#config#single_quote', 'false')
 
 " print spaces between brackets
 " default: 'true'
+" See more: https://prettier.io/docs/en/options.html#bracket-spacing
 let g:prettier#config#bracket_spacing = get(g:,'prettier#config#bracket_spacing', 'true')
 
 " put > on the last line instead of new line
 " default: 'false'
+" See more: https://prettier.io/docs/en/options.html#jsx-brackets
 let g:prettier#config#jsx_bracket_same_line = get(g:,'prettier#config#jsx_bracket_same_line', 'false')
 
 " avoid wrapping a single arrow function param in parens
 " avoid|always
 " default: 'always'
+" See more: https://prettier.io/docs/en/options.html#arrow-function-parentheses
 let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'always')
 
 " Print trailing commas wherever possible when multi-line.
 " none|es5|all
 " default: 'es5'
+" See more: https://prettier.io/docs/en/options.html#trailing-commas
 let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'es5')
 
 " restrict itself to only format files that contain a special comment @prettier or @format
+" See more: https://prettier.io/docs/en/options.html#require-pragma
 let g:prettier#config#require_pragma=  get(g:, 'prettier#config#require_pragma', 'false')
 
 " synchronous by default


### PR DESCRIPTION
**Summary**

Currently `vim-prettier` provides a set of overriding configs (like `#config#tab_width`, `#config#trailing_comma`,...) but there're some not respecting the [Prettier CLI's default options](https://prettier.io/docs/en/options.html), e.g.:

* `#config#trailing_comma` is `none` while it's `es5` by default.
* `#config#arrow_parens` is `avoid` while it's `always` by default.

This can lead to confusing situations, for instance: auto-saving produces strange diffs comparing to CLI running.

This PR aims to update those configs to respect official document, as well as provide references to it.

**Test Plan**

N/A
