### PR TITLE
Return cwd as default from s:ResolveExecutable

### DIFF
--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -64,7 +64,7 @@ endfunction
 
 function! s:ResolveExecutable(...) abort
   let l:rootDir = a:0 > 0 ? a:1 : 0
-  let l:exec = -1
+  let l:exec = "."
 
   if isdirectory(l:rootDir)
     let l:dir = s:TraverseAncestorDirSearch(l:rootDir)


### PR DESCRIPTION
**Summary**

This fixes an issue on nvim (v0.5.0, likely others) in which a local `prettier` installation is not found by `s:ResolveExecutable`, and it returns a `-1` for  `executable(_)` to choke on with a `String required` error.
The proposed change returns a sane default.