### PR TITLE
Support MDX in autoformat

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -4,5 +4,5 @@ let b:prettier_ft_default_args = {
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn call prettier#Autoformat()
+  autocmd BufWritePre *.markdown,*.md,*.mdown,*.mkd,*.mkdn,*.mdx call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
Noticed that MDX doesn't work out of the box with vim-prettier. Adding this to my local config did the trick.