### PR TITLE
Fix interference with coc-tsserver

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,3 +1,4 @@
 augroup PrettierFileDetect
-  autocmd BufNewFile,BufReadPost *.js,*jsx setfiletype javascript
+  autocmd BufNewFile,BufReadPost *.js setfiletype javascript
+  autocmd BufNewFile,BufReadPost *.jsx setfiletype javascript.jsx
 augroup end

--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,3 +1,4 @@
 augroup PrettierFileDetect
-  autocmd BufNewFile,BufReadPost *.ts,*.tsx setfiletype typescript
+  autocmd BufNewFile,BufReadPost *.ts setfiletype typescript
+  autocmd BufNewFile,BufReadPost *.tsx setfiletype typescript.tsx
 augroup end


### PR DESCRIPTION
**Summary**

[`coc-tsserver`](https://github.com/neoclide/coc-tsserver) has the following notice in its README:

> Note: for React to work as expected, you need your JSX filetype to be `javascript.jsx` or `javascriptreact` and your TSX filetype to be `typescript.jsx` or `typescript.tsx` or `typescriptreact`.

With the setting that `vim-prettier` uses (`typescript`), `tsx` files become an error-riddled mess with `coc-tsserver`.

I've found that `vim-prettier` works better than [`coc-prettier`](https://github.com/neoclide/coc-prettier), so I'd prefer to keep `vim-prettier` installed rather than use `coc-prettier`.

**Test Plan**

1. Confirm prettier still works as expected (appears to work for me)