### PR TITLE
fix: always pass a string to executable(...)

### DIFF
--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -13,7 +13,7 @@ function! prettier#resolver#executable#getPath() abort
   endif
 
   let l:localExec = s:ResolveExecutable(getcwd())
-  if executable(l:localExec)
+  if executable("" . l:localExec)
     return fnameescape(l:localExec)
   endif
 


### PR DESCRIPTION
**Summary**

Fixes #276 

**Test Plan**

I tested on NeoVim Nightly, and it works.  Still have to test in NeoVim 0.4, and Vim8.
