### PR TITLE
fix incorrect reference to PrettierFragment in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ If your are on vim 8+ you can also trigger async formatting by:
 
 You can send to prettier your entire buffer but ensure that it formats only your selection.
 
-**note: ** differs from `:PrettierFragment` by sending the entire buffer to prettier, allowing identation level to be preserved, but it requires the whole file to be valid.
+**note:** differs from `:PrettierFragment` by sending the entire buffer to prettier, allowing identation level to be preserved, but it requires the whole file to be valid.
 
 ```vim
 :PrettierPartial
@@ -120,7 +120,7 @@ You can send to prettier your entire buffer but ensure that it formats only your
 
 You can send to prettier your current selection as a fragment of same type as the file being edited.
 
-**note: ** differs from `:PrettierFragment` by sending only the current selection to prettier, this allows for faster formatting but wont preserve indentation.
+**note:** differs from `:PrettierPartial` by sending only the current selection to prettier, this allows for faster formatting but wont preserve indentation.
 
 ```vim
 :PrettierFragment

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -94,7 +94,7 @@ You can check what is the resolved `prettier` cli version by:
 You can send to prettier your entire buffer but ensure that it
 formats only your selection.
 
-**note: ** differs from `:PrettierFragment` by sending the entire buffer
+**note:** differs from `:PrettierFragment` by sending the entire buffer
 to prettier, allowing identation level to be preserved, but it requires
 the whole file to be valid.
 >
@@ -103,7 +103,7 @@ the whole file to be valid.
 You can send to prettier your current selection as a fragment of same type as
 the file being edited.
 
-**note: ** differs from `:PrettierPartial` by sending only the current selection
+**note:** differs from `:PrettierPartial` by sending only the current selection
 to prettier, this allows for faster formatting but wont preserve indentation.
 >
   :PrettierFragment


### PR DESCRIPTION
**Summary**

Fix incorrect reference to `:PartialFragment` in the readme and fix formatting on bold text

**Test Plan**

[...]
