### PR TITLE
enh: save buffer marks between runs

### DIFF
--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -15,17 +15,17 @@ function! prettier#utils#buffer#replace(lines, startSelection, endSelection) abo
   try | silent undojoin | catch | endtry
 
   " delete all lines on the current buffer
-  silent! execute '%delete _'
+  silent! execute 'lockmarks %delete _'
 
   " replace all lines from the current buffer with output from prettier
   let l:idx = 0
   for l:line in l:newBuffer
-    silent! call append(l:idx, l:line)
+    silent! lockmarks call append(l:idx, l:line)
     let l:idx += 1
   endfor
-  
+
   " delete trailing newline introduced by the above append procedure
-  silent! execute '$delete _'
+  silent! lockmarks execute '$delete _'
 
   " Restore view
   call winrestview(l:winview)


### PR DESCRIPTION
**Summary**

Fix marks buffer marks being lost after Prettier runs.

Fixes this issue #251 

**Test Plan**

- add a mark with `ma`, move around, jump to it with `'a`
- "uglify" a line in your code, run `:Prettier` to fix it
- now do `'a`, vim should jump the cursor to the marked position with `ma`. The line might not correspond exactly with the previous line due to lines changed by Prettier, but it should be close.
