### PR TITLE
Update prettier to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@prettier/plugin-php": "^0.16.3",
     "@prettier/plugin-ruby": "^0.8.0",
     "@prettier/plugin-xml": "^0.7.2",
-    "prettier": "^2.0.4"
+    "prettier": "^2.3.1"
   },
   "devDependencies": {
     "colors": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2660,10 +2660,10 @@ prettier@>=1.10, prettier@^1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.0.4:
-  version "2.0.4"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
-  integrity sha1-LRuuFz41WZbuNV7Jgwp6HuBUV+8=
+prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
+  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
**Summary**

Update prettier to its latest version. I found a problem with a prettier plugin not working when the version installed in the vim-prettier directory was used (`:Prettier` was not working on the files formatted by that plugin, but it was for javascript files) and upgrading fixed it.

**Test Plan**

I manually tested locally, but only in vim8.