### PR TITLE
Readme: add note about configuring autoformat when config is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ let g:prettier#autoformat_require_pragma = 0
 
 Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory. Note that this will override the `g:prettier#autoformat` setting!
 
+Again, this setting will have no effect if not combined with `let g:prettier#autoformat_require_pragma = 0`.
+
 ```vim
 let g:prettier#autoformat_config_present = 1
 ```


### PR DESCRIPTION
**Summary**

Adds a simple note to the `autoformat_config_present` section documenting that the setting does nothing without switching off `autoformat_require_pragma` first. I found this confusing when setting up this plugin myself, and the reactions in #191 seem to indicate I wasn't alone 😅
