### PR TITLE
Fix cursor jumping to top when redo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV PACKAGES="\
     ruby \
     ruby-dev \
     ruby-json \
-    python \
+    python2 \
     python3 \
     py-pip \
     nodejs \

--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -14,18 +14,11 @@ function! prettier#utils#buffer#replace(lines, startSelection, endSelection) abo
   execute "normal! a\<BS>"
   try | silent undojoin | catch | endtry
 
-  " delete all lines on the current buffer
-  silent! execute 'lockmarks %delete _'
+  " insert all lines from prettier-ed buffer before the first line on the current buffer
+  silent! lockmarks call append(0, l:newBuffer)
 
-  " replace all lines from the current buffer with output from prettier
-  let l:idx = 0
-  for l:line in l:newBuffer
-    silent! lockmarks call append(l:idx, l:line)
-    let l:idx += 1
-  endfor
-
-  " delete trailing newline introduced by the above append procedure
-  silent! lockmarks execute '$delete _'
+  " then delete all the original lines on the current buffer
+  silent! lockmarks execute (len(l:newBuffer) + 1).',$delete _'
 
   " Restore view
   call winrestview(l:winview)


### PR DESCRIPTION
**Summary**

This resolves #226.

Issue:
When pressing `u` after `:Prettier`, the cursor stays. (#207) However when pressing `Ctrl-r` after `u` the cursor won't stay but will jump to the top of the file.

Cause:
I'm not sure, but it seems that the cursor position information is lost during `:Prettier` operation.

`:Prettier` essentially deletes all the contents of the current buffer and writes pre-prettier'ed contents into that buffer.

https://github.com/prettier/vim-prettier/blob/5e6cca21e12587c02e32a06bf423519eb1e9f1b2/autoload/prettier/utils/buffer.vim#L17-L28

When changes happen, Vim stores snapshots [including cursor positions](https://github.com/vim/vim/blob/9acf2d8be93f3b50607279e7f3484b019675d0a7/src/undo.c#L590) before those changes are applied. Then when the user presses `Ctrl-r`, Vim reads the cursor position stored in the snapshot. If the cursor position is in the redo block, the current cursor will move to that cursor position. However if the cursor position is outside the redo block, the current cursor will move to "[the first line that actually changed](https://github.com/vim/vim/blob/9acf2d8be93f3b50607279e7f3484b019675d0a7/src/undo.c#L2728-L2741)".

In vim-prettier's case the cursor position is not in the redo block because all the lines upon one of which the cursor position was located are deleted. Thus the current cursor will move to the top of the file which is the first of the lines where the changes occurred.

Fix:
Change the order of `:Prettier` process:
- Before: delete the original contents and write pre-prettier'ed contents.
- After: write pre-prettier'ed contents and delete the original contents.

**Test Plan**

For both Vim 8.2 and Neovim 0.6 check if the cursor jumps to the top of the file.

1. Create an empty JavaScript file `test.js`
2. Add 10 lines of `const a = 1;` and indent one of these lines:
    - the first line. (This is the first test case)
    - the last line. (This is the second test case)
    - line 3, i.e. somewhere between the first and the last. (This is the third test case)
3. `:Prettier`
4. `u`
5. `Ctrl-r`