### PR TITLE
Improve autoformatting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,22 @@ Allow auto formatting for files without "@format" or "@prettier" tag
 let g:prettier#autoformat_require_pragma = 0
 ```
 
-**NOTE** The previous two options can be used together for autoformatting files on save without `@format` or `@prettier` tags
+**NOTE** The previous two options can be used together for autoformatting files on save without `@format` or `@prettier` tags.
+In this case, all files are autoformatted despite a config file being present.
 
 ```vim
 let g:prettier#autoformat = 1
 let g:prettier#autoformat_require_pragma = 0
 ```
 
-Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory. Note that this will override the `g:prettier#autoformat` setting!
+In case autoformatting is only desired when a config file is present:
+
+```
+let g:prettier#autoformat_config_present = 1
+let g:prettier#autoformat_require_pragma = 0
+```
+
+To toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directoryy use `autoformat_config_present`. Note that this will override the `g:prettier#autoformat` setting!
 
 ```vim
 let g:prettier#autoformat_config_present = 1


### PR DESCRIPTION
As many others:

- #191 
- #317

I had problems understanding when autoformatting is truly applied with the config file present. A [comment](https://github.com/prettier/vim-prettier/issues/191#issuecomment-614280489) by @[vadimshvetsov](https://github.com/vadimshvetsov) received > 50 👍🏼, which I think is an indicator for the information people are seeking. Hence, I'm proposing to add his comment in slightly edited form to the readme.md.