### PR TITLE
feat(resolver): skip inappropriate directories in ancestors traversal

### DIFF
--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -50,7 +50,9 @@ function! s:TraverseAncestorDirSearch(rootDir) abort
   while 1
     let l:searchDir = l:root . '/' . l:dir
     if isdirectory(l:searchDir)
-      return l:searchDir
+      if executable(s:GetExecPath(l:searchDir))
+        return l:searchDir
+      endif
     endif
 
     let l:parent = fnamemodify(l:root, ':h')


### PR DESCRIPTION
**Summary**

This PR fixes resolving of locally installed prettier executable in multi packages repositories with hoisted dependencies.

Please consider the following files structure:

```
.
├── index.ts              <--- PrettierCliPath is correctly resolved to the locally installed executable
├── node_modules
│   └── .bin
│       └── prettier
├── package.json          <--- Root package with prettier installed as a dev dependency
└── packages                  that should be used for all source files in this repository
    └── some-package
        ├── index.ts      <--- PrettierCliPath SHOULD be resolved to the ../../node_modules/.bin/prettier
        ├── node_modules
        │   └── .bin
        └── package.json  <--- One of the mono repository packages that may have its own
                               dependencies. But it doesn't have prettier in its node_modules/.bin
```

Without this PR the resolved cli path for `./packages/some-package/index.ts` is globally installed or the plugin's version of prettier.  
With this PR the resolved path is `./node_modules/.bin/prettier`.
