### PR TITLE
Support twig files with .html formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn|npm installed globally.
 " post install (yarn install | npm install) then load plugin only for editing supported files
 Plug 'prettier/vim-prettier', {
   \ 'do': 'yarn install --frozen-lockfile --production',
-  \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'svelte', 'yaml', 'html'] }
+  \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'svelte', 'yaml', 'html', 'twig'] }
 ```
 
 or simply enable for all formats by:
@@ -232,7 +232,7 @@ To run vim-prettier not only before saving, but also after changing text or leav
 " when running at every change you may want to disable quickfix
 let g:prettier#quickfix_enabled = 0
 
-autocmd TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.svelte,*.yaml,*.html PrettierAsync
+autocmd TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.svelte,*.yaml,*.html,*.twig PrettierAsync
 ```
 
 ### Overwrite default prettier configuration

--- a/ftdetect/twig.vim
+++ b/ftdetect/twig.vim
@@ -1,0 +1,3 @@
+augroup PrettierFileDetect
+  autocmd BufNewFile,BufReadPost *.twig setfiletype html
+augroup end

--- a/ftplugin/twig.vim
+++ b/ftplugin/twig.vim
@@ -1,0 +1,7 @@
+" markdown/php files run this as well
+" https://stackoverflow.com/questions/22839269/why-does-vim-default-markdown-ftplugin-source-html-ftplugins-is-there-any-ways
+if expand('%:e') ==# 'twig'
+  let b:prettier_ft_default_args = {
+    \ 'parser': 'html',
+    \ }
+endif

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -174,5 +174,5 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 
 augroup Prettier
   autocmd!
-  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.gql,*.markdown,*.md,*.mdown,*.mkd,*.mkdn,*.mdx,*.vue,*.svelte,*.yml,*.yaml,*.html,*.php,*.rb,*.ruby,*.xml noautocmd call prettier#Autoformat()
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.gql,*.markdown,*.md,*.mdown,*.mkd,*.mkdn,*.mdx,*.vue,*.svelte,*.yml,*.yaml,*.html,*.php,*.rb,*.ruby,*.xml,*.twig noautocmd call prettier#Autoformat()
 augroup end


### PR DESCRIPTION
**Summary**

It looks like this isn't maintained anymore, but here's hoping for the best!

`.twig` files are commonplace now in many frontend circles and I think handling them out of the box the same way that HTML is handled is a good step idea. This is a very small change that mostly involved just copying/pasting the `ft` files for HTML and modifying them very slightly. 

I also updated the documentation where I thought it was appropriate to do so.
