### PR TITLE
feat(resolver): Resolve executable starting from open file path

### DIFF
--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -12,7 +12,7 @@ function! prettier#resolver#executable#getPath() abort
     return l:user_defined_exec_path
   endif
 
-  let l:localExec = s:ResolveExecutable(getcwd())
+  let l:localExec = s:ResolveExecutable(expand('%:p:h'))
   if executable(l:localExec)
     return fnameescape(l:localExec)
   endif


### PR DESCRIPTION
**Summary**

If vim's current working directory is above the root of an npm project, vim-prettier will be unable to find the correct prettier executable despite editing a file that is within that JS project. This PR changes the executable resolver to search starting from the open file.

This probably also enables monorepo scenarios where the editor is open at the root and projects have different prettier configurations or versions.

**Test Plan**

I needed to make this change for the plugin to work for my use-case, and it has been working so far.
