### PR TITLE
WIP: detect js by shebang and run by filetype

### DIFF
--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,3 +1,4 @@
 augroup PrettierFileDetect
   autocmd BufNewFile,BufReadPost *.js,*jsx setfiletype javascript
+  autocmd BufRead,BufNewFile * if getline(1) =~ '#!/.*\<\(bun\|deno\|node\|zx\)\>' | setfiletype javascript | endif
 augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -175,4 +175,5 @@ nnoremap <silent> <Plug>(PrettierCliPath) :PrettierCliPath<CR>
 augroup Prettier
   autocmd!
   autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.gql,*.markdown,*.md,*.mdown,*.mkd,*.mkdn,*.mdx,*.vue,*.svelte,*.yml,*.yaml,*.html,*.php,*.rb,*.ruby,*.xml noautocmd call prettier#Autoformat()
+  autocmd FileType javascript,typescript noautocmd BufWritePre <buffer> call prettier#Autoformat()
 augroup end

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -122,7 +122,7 @@ let g:prettier#config#arrow_parens = get(g:,'prettier#config#arrow_parens', 'alw
 
 " Define the flavor of line endings
 " lf|crlf|cr|all
-" defaut: 'lf' 
+" defaut: 'lf'
 let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
 
 " Print trailing commas wherever possible when multi-line.
@@ -156,7 +156,7 @@ command! -nargs=? -range=% PrettierCliPath call prettier#PrettierCliPath()
 " sends selected text to prettier cli for formatting
 command! -nargs=? -range=% PrettierFragment call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>, 0)
 
-" sends entire buffer to prettier cli but format just selection 
+" sends entire buffer to prettier cli but format just selection
 command! -nargs=? -range=% PrettierPartial call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>, 1)
 
 " map command


### PR DESCRIPTION
Re:  #340

**Summary**

This doesn't actually work yet. The same lines work for me in my local config, but not directly in the vim-prettier plugin. I'm not clear as to why.

**Test Plan**

1. Create the test file `./test-no-extension` with these contents:
   `./test-no-extension`
   ```js
   #!/usr/bin/env node

   function main() {
   console.log('Hello');
   }
   ```
2. Open the file
   ```sh
   vim ./test-no-extension
   ```
3. Save the file
   ```vim
   :w
   ```

If it auto-formats, it worked.