### PR TITLE
Explain how to disable vim-prettier default settings in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ let g:prettier#config#require_pragma = 'false'
 let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
 ```
 
+To ignore vim-prettier default settings when a config file is found, set `config_precedence` to
+[`file-override`](https://prettier.io/docs/en/cli.html#--config-precedence):
+
+```
+let g:prettier#config#config_precedence = 'file-override'
+```
+
 ### REQUIREMENT(S)
 
 If the `prettier` executable can't be found by Vim, no code formatting will happen


### PR DESCRIPTION
I spent a while figuring out why vim-prettier was adding some default CLI options like `--tab-width=4` to the prettier command it was running, which was causing changes that would break my CI build when it would check the codebase against a `.prettierrc` that (obviously) didn't include vim-prettier's default settings.

In case anyone encounters a similar issue, here's what I found out:

1. vim-prettier always adds a bunch of CLI flags with its own default settings to the prettier command it runs. See https://github.com/prettier/vim-prettier/blob/e122231/autoload/prettier/resolver/config.vim#L8
2. it even overrides some of its own default settings, like if `g:prettier#config#tab_width` is set to `auto` (the default), it will set it to the value of the `shiftwidth` vim setting (see https://github.com/prettier/vim-prettier/blob/e122231/autoload/prettier/resolver/config.vim#L56). In my case it would set it to 4 on markdown files

There doesn't seem to be any option to prevent vim-prettier from adding all those CLI flags, but thankfully we can ask prettier to ignore them whenever a config file is passed with the `--config-precedence prefer-file` option.

I thought this deserved a clearer mention in the section of the README that mentions the vim-prettier default config. WDYT?

(Thanks to @twm who put me on the right track in this issue comment: https://github.com/prettier/vim-prettier/issues/266#issuecomment-953417529)