### PR TITLE
Replace/remove deprecated options in Prettier 3.0

### DIFF
--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -32,7 +32,7 @@ function! prettier#resolver#config#resolve(config, hasSelection, start, end) abo
           \ get(a:config, 'requirePragma', g:prettier#config#require_pragma) .
           \ ' --end-of-line=' .
           \ get(a:config, 'endOfLine', g:prettier#config#end_of_line) .
-          \ ' --loglevel error '.
+          \ ' --log-level error '.
           \ ' --stdin '
 
   return l:cmd

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -32,8 +32,7 @@ function! prettier#resolver#config#resolve(config, hasSelection, start, end) abo
           \ get(a:config, 'requirePragma', g:prettier#config#require_pragma) .
           \ ' --end-of-line=' .
           \ get(a:config, 'endOfLine', g:prettier#config#end_of_line) .
-          \ ' --log-level error '.
-          \ ' --stdin '
+          \ ' --log-level error '
 
   return l:cmd
 endfunction


### PR DESCRIPTION
**Summary**

- fix: Update --loglevel to --log-level (Pretter 3.0)
- fix: Remove --stdin (Pretter 3.0)

**Test Plan**

1. Open a yaml file
0. Format the file

Using current master branch (5e6cca21e12587c02e32a06bf423519eb1e9f1b2) it shows
```
[warn] --jsx-bracket-same-line is deprecated.
[warn] Ignored unknown option --loglevel=error. Did you mean --log-level?
[warn] Ignored unknown option --stdin.
```
...at the top of the file.