### PR TITLE
Fix failed to parse buffer when autoformat

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -80,8 +80,11 @@ function! prettier#Prettier(...) abort
       let l:endSelection = line('$')
     endif
 
-    " format buffer
-    call prettier#job#runner#run(l:cmd, l:startSelection, l:endSelection, l:async)
+    " only format files with extension js, jsx, ts, tsx
+    if expand('%:e') =~ '\v^js$|^jsx$|^ts$|^tsx$'
+        " format buffer
+        call prettier#job#runner#run(l:cmd, l:startSelection, l:endSelection, l:async)
+    endif
   else
     call prettier#logging#error#log('EXECUTABLE_NOT_FOUND_ERROR')
   endif


### PR DESCRIPTION
**Summary**
When autoformat is enabled, it tries to format the buffer even if the buffer is not actually a correct file for prettier to format. With this fix, only files with extension `js`, `jsx`, `ts`, `tsx` will be formatted, other than that it will be ignored.
