### PR TITLE
Remove specified versions of dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "lint": "vint --version && vint ."
   },
   "dependencies": {
-    "@prettier/plugin-lua": "0.0.1",
-    "@prettier/plugin-php": "^0.16.3",
-    "@prettier/plugin-ruby": "^0.8.0",
-    "@prettier/plugin-xml": "^0.7.2",
-    "prettier": "^3.0.3",
-    "prettier-plugin-svelte": "^2.3.1"
+    "@prettier/plugin-lua": "",
+    "@prettier/plugin-php": "",
+    "@prettier/plugin-ruby": "",
+    "@prettier/plugin-xml": "",
+    "prettier": "",
+    "prettier-plugin-svelte": ""
   },
   "devDependencies": {
     "colors": "^1.3.2",


### PR DESCRIPTION
**Summary**
Let npm decide which version to use automatically by removing specific ranges from package.json.

According to the npm docs, this change is valid.
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#dependencies

This is a fix for https://github.com/prettier/vim-prettier/issues/349#issuecomment-2156835956.

**Test Plan**

Already ran `:Prettier` in vim8 and nvim with a `test.html` open containing the below line.

```html
<!DOCTYPE html><html><head><title>test</title></head><body>test</body></html>
```

Running `:Prettier` produced the expected results.

```html
<!doctype html>
<html>
        <head>
                <title>test</title>
        </head>
        <body>
                test
        </body>
</html>
```