### PR TITLE
Windows's support for powershell and scripts entrypoints.

### DIFF
--- a/autoload/prettier/job/async/neovim.vim
+++ b/autoload/prettier/job/async/neovim.vim
@@ -16,7 +16,14 @@ function! prettier#job#async#neovim#run(cmd, startSelection, endSelection) abort
   let l:out = []
   let l:err = []
 
-  let l:job = jobstart([&shell, &shellcmdflag, a:cmd], {
+  if has('win32') || has('win64')
+    " windows doesn't cope well with job cmd lists
+    let l:job_cmd = a:cmd
+  else
+    let l:job_cmd = [&shell, &shellcmdflag, a:cmd]
+  endif
+
+  let l:job = job_start(l:job_cmd, {
     \ 'stdout_buffered': 1,
     \ 'stderr_buffered': 1,
     \ 'on_stdout': {job_id, data, event -> extend(l:out, data)},

--- a/autoload/prettier/job/async/vim.vim
+++ b/autoload/prettier/job/async/vim.vim
@@ -3,12 +3,19 @@ let s:prettier_job_running = 0
 function! prettier#job#async#vim#run(cmd, startSelection, endSelection) abort
   if s:prettier_job_running == 1
     return
-  endif 
+  endif
   let s:prettier_job_running = 1
 
   let l:bufferName = bufname('%')
 
-  let l:job = job_start([&shell, &shellcmdflag, a:cmd], {
+  if has('win32') || has('win64')
+    " windows doesn't cope well with job cmd lists
+    let l:job_cmd = a:cmd
+  else
+    let l:job_cmd = [&shell, &shellcmdflag, a:cmd]
+  endif
+
+  let l:job = job_start(l:job_cmd, {
     \ 'out_io': 'buffer',
     \ 'err_cb': {channel, msg -> s:onError(msg)},
     \ 'close_cb': {channel -> s:onClose(channel, a:startSelection, a:endSelection, l:bufferName)}})

--- a/autoload/prettier/job/runner.vim
+++ b/autoload/prettier/job/runner.vim
@@ -27,7 +27,7 @@ function! s:asyncFormat(cmd, startSelection, endSelection) abort
     " required for Windows support on async operations 
     let l:cmd = a:cmd
     if has('win32') || has('win64')
-      let l:cmd = 'cmd.exe /c ' . a:cmd
+        let l:cmd = g:prettier#win_async_shell_cmds . ' ' . a:cmd
     endif
 
     if s:isAsyncVim

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -137,6 +137,16 @@ By default parsing errors will open the quickfix but can also be disabled
 >
   let g:prettier#quickfix_enabled  = 1
 <
+Running async commands in windows is tricky and usually requires running an extra shell.
+It is set up by default to use cmd as:
+>
+  let g:prettier#win_async_shell_cmds = 'cmd /c'
+<
+but it can be modified to use powershell (desktop or core) or powershell scripts as:
+>
+  let g:prettier#win_async_shell_cmds = 'powershell -Command'
+  let g:prettier#win_async_shell_cmds = 'pwsh -File'
+<
 By default we auto focus on the quickfix when there are errors but can also be disabled
 >
   let g:prettier#quickfix_auto_focus = 0

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -137,6 +137,10 @@ let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 
 " See more: https://prettier.io/docs/en/options.html#require-pragma
 let g:prettier#config#require_pragma=  get(g:, 'prettier#config#require_pragma', 'false')
 
+" Commands to decorate the async job on windows
+" default: 'cmd /c'
+let g:prettier#win_async_shell_cmds = get(g: , 'prettier#win_async_shell_cmds', 'cmd /c')
+
 " synchronous by default
 command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_async, <line1>, <line2>, g:prettier#partial_format)
 


### PR DESCRIPTION
**Summary**

Windows's support for powershell and scripts entrypoints. This way prettier can be executed over a container or wsl.

For example, the following script can be used as entrypoint to use a containerized version of prettier:

```pwsh
# See https://github.com/prettier/vim-prettier/pull/357
# Using .ps1 entrypoints under cmd.exe requires file association changes:
#  cmd> assoc .ps1=Microsoft.PowerShellScript.1
#  cmd> ftype Microsoft.PowerShellScript.1="C:\Program Files\PowerShell\7\pwsh.exe" "-File" "%1" %*
$params = @{
    Name = "prettierImageName"
    Value = "jauderho/prettier"
    Description = "The docker image to run prettier cli"
    Option = "Constant"
    Scope = "Script"
}
Set-Variable @params

$encoding = '$OutputEncoding = New-Object System.Text.UTF8Encoding;'
$encoding += '[Console]::InputEncoding = $OutputEncoding;' 
$encoding += '[Console]::OutputEncoding = $OutputEncoding;' 
$encoding += '$PSDefaultParameterValues["*:Encoding"] = "utf8";'

Invoke-Expression -Command $encoding

# check docker
if (-not (gcm docker -ErrorAction SilentlyContinue))
{
    Write-Error "Docker is not installed"
        exit 1
}

# check for the image
$image = docker images --format '{{json .}}' |
    ? { $_ -notmatch "failed to get console mode for (stdout|stdin)"} |
    ConvertFrom-Json | ? Repository -eq $prettierImageName

if (-not $image)
{
    Write-Error "Docker image jauderho/prettier is not installed"
        exit 2
}

# retrieve arguments (workaround because passing @args directly to docker fails)
$cmdline = [System.Environment]::CommandLine
$ScriptName = (gi $PSCommandPath).Name
if ($cmdline -match $ScriptName)
{
    $filtered = $cmdline -replace  ('^.*' + $ScriptName + '\s+'),'' # remove invocation
    $filtered = $filtered -replace  '\s*(}\s*)?\d?>.*$','' # remove redirection
    $use_input = $filtered | sls '--stdin-filepath=\S*'
    $filtered = $filtered -replace  '--stdin-filepath=\S*','' # remove filepath
    $filtered = $filtered.trim() -split '\s+'
}
else
{
    $filtered = $args | ? { $_ -notmatch '--stdin-filepath' }
    $use_input = $args -ne $filtered
}

# run docker or delegate to blocking script
if ($use_input -ne $null)
{
    $input | docker run -i --rm $prettierImageName @filtered 2>$null
}
else
{
    docker run --rm $prettierImageName @args 2>$null
}
```

The .vimrc will require the following config:

```vim
if has('win32')
    " Lure vim into identify powershell scripts as exes
    if !($PATHEXT=~'\.PS1')
        let $PATHEXT.=';.PS1'
    endif

    let g:prettier#exec_cmd_path  = "<script path>/docker-prettier.ps1"
    let g:prettier#win_async_shell_cmds = (executable('pwsh') ? 'pwsh' : 'powershell') . ' -File'
endif

" enable autocommands
let g:prettier#autoformat_config_present = 1
```