### PR TITLE
Dev/compatibility revival

### DIFF
--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -25,6 +25,26 @@ jobs:
             git diff-tree --check --no-commit-id --root -r HEAD
           fi
 
+  lint:
+    name: Vimscript lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Python venv support
+        run: sudo apt-get update && sudo apt-get install -y python3-venv
+
+      - name: Run Vimscript lint
+        run: yarn lint
+
   smoke:
     name: Targeted Vim smoke check
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -5,6 +5,26 @@ on:
   pull_request:
 
 jobs:
+  whitespace:
+    name: Whitespace diff check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whitespace in committed diff
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --check "origin/${{ github.base_ref }}...HEAD"
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            git diff --check "${{ github.event.before }}..HEAD"
+          else
+            git diff-tree --check --no-commit-id --root -r HEAD
+          fi
+
   smoke:
     name: Targeted Vim smoke check
     runs-on: ubuntu-latest
@@ -21,6 +41,9 @@ jobs:
 
       - name: Install Vim
         run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Verify Vim capabilities
+        run: node scripts/vim-version.js
 
       - name: Report Yarn version
         run: yarn --version
@@ -47,6 +70,9 @@ jobs:
 
       - name: Install Vim
         run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Verify Vim capabilities
+        run: node scripts/vim-version.js
 
       - name: Report Yarn version
         run: yarn --version

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -103,6 +103,76 @@ jobs:
       - name: Run known-passing formatting fixtures
         run: yarn test:formatting:passing
 
+  core-formatting:
+    name: Core formatting fixtures
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Vim
+        run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Verify Vim capabilities
+        run: node scripts/vim-version.js
+
+      - name: Report Yarn version
+        run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run core formatting fixtures
+        run: yarn test:formatting:core
+
+  core-formatting-exec:
+    name: Core formatting fixtures with Prettier ${{ matrix.prettier-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        prettier-version:
+          - 2.8.8
+          - latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Vim
+        run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Verify Vim capabilities
+        run: node scripts/vim-version.js
+
+      - name: Report Yarn version
+        run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install matrix Prettier
+        run: npm install --prefix "$RUNNER_TEMP/prettier-${{ matrix.prettier-version }}" "prettier@${{ matrix.prettier-version }}"
+
+      - name: Run core formatting fixtures with matrix Prettier
+        run: yarn test:formatting:core:exec
+        env:
+          PRETTIER_EXEC_CMD_PATH: ${{ runner.temp }}/prettier-${{ matrix.prettier-version }}/node_modules/.bin/prettier
+
   quarantined-formatting-discovery:
     name: Quarantined Lua/Ruby formatting discovery
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -31,8 +31,34 @@ jobs:
       - name: Run targeted smoke check
         run: yarn test:smoke
 
-  full-formatting-discovery:
-    name: Full formatting suite discovery
+  known-passing-formatting:
+    name: Known-passing formatting fixtures
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Vim
+        run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Report Yarn version
+        run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run known-passing formatting fixtures
+        run: yarn test:formatting:passing
+
+  quarantined-formatting-discovery:
+    name: Quarantined Lua/Ruby formatting discovery
     runs-on: ubuntu-latest
     continue-on-error: true
 
@@ -55,5 +81,5 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Run full formatting suite as discovery
-        run: yarn test
+      - name: Run quarantined Lua/Ruby formatting discovery
+        run: yarn test:formatting:quarantined

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -243,31 +243,3 @@ jobs:
         run: yarn test:formatting:core:exec
         env:
           PRETTIER_EXEC_CMD_PATH: ${{ runner.temp }}/prettier-${{ matrix.prettier-version }}/node_modules/.bin/prettier
-
-  quarantined-formatting-discovery:
-    name: Quarantined Lua/Ruby formatting discovery
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    continue-on-error: true
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: yarn
-
-      - name: Install Vim
-        run: sudo apt-get update && sudo apt-get install -y vim
-
-      - name: Report Yarn version
-        run: yarn --version
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Run quarantined Lua/Ruby formatting discovery
-        run: yarn test:formatting:quarantined

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -1,8 +1,7 @@
 name: Compatibility Smoke
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -92,15 +92,19 @@ jobs:
           - name: Vim 8.2 latest patch
             version: v8.2.5172
             neovim: false
+            args: ''
           - name: Vim stable
             version: stable
             neovim: false
+            args: ''
           - name: Neovim 0.9 latest patch
             version: v0.9.5
             neovim: true
+            args: --headless
           - name: Neovim stable
             version: stable
             neovim: true
+            args: --headless
 
     steps:
       - name: Check out repository
@@ -124,6 +128,7 @@ jobs:
         run: node scripts/vim-version.js
         env:
           VIM_EXECUTABLE: ${{ steps.editor.outputs.executable }}
+          VIM_EXECUTABLE_ARGS: ${{ matrix.args }}
 
       - name: Report Yarn version
         run: yarn --version
@@ -135,6 +140,7 @@ jobs:
         run: yarn test:smoke
         env:
           VIM_EXECUTABLE: ${{ steps.editor.outputs.executable }}
+          VIM_EXECUTABLE_ARGS: ${{ matrix.args }}
 
   known-passing-formatting:
     name: Known-passing formatting fixtures

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -4,10 +4,15 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   whitespace:
     name: Whitespace diff check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Check out repository
@@ -28,6 +33,7 @@ jobs:
   lint:
     name: Vimscript lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Check out repository
@@ -48,6 +54,7 @@ jobs:
   smoke:
     name: Targeted Vim smoke check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Check out repository
@@ -77,6 +84,7 @@ jobs:
   editor-compatibility:
     name: Editor smoke check (${{ matrix.name }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -132,6 +140,7 @@ jobs:
   known-passing-formatting:
     name: Known-passing formatting fixtures
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
@@ -161,6 +170,7 @@ jobs:
   core-formatting:
     name: Core formatting fixtures
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
@@ -190,6 +200,7 @@ jobs:
   core-formatting-exec:
     name: Core formatting fixtures with Prettier ${{ matrix.prettier-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -231,6 +242,7 @@ jobs:
   quarantined-formatting-discovery:
     name: Quarantined Lua/Ruby formatting discovery
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     continue-on-error: true
 
     steps:

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -74,6 +74,61 @@ jobs:
       - name: Run targeted smoke check
         run: yarn test:smoke
 
+  editor-compatibility:
+    name: Editor smoke check (${{ matrix.name }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Vim 8.2 latest patch
+            version: v8.2.5172
+            neovim: false
+          - name: Vim stable
+            version: stable
+            neovim: false
+          - name: Neovim 0.9 latest patch
+            version: v0.9.5
+            neovim: true
+          - name: Neovim stable
+            version: stable
+            neovim: true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Set up editor
+        id: editor
+        uses: rhysd/action-setup-vim@v1
+        with:
+          version: ${{ matrix.version }}
+          neovim: ${{ matrix.neovim }}
+          configure-args: --with-features=huge
+
+      - name: Verify editor capabilities
+        run: node scripts/vim-version.js
+        env:
+          VIM_EXECUTABLE: ${{ steps.editor.outputs.executable }}
+
+      - name: Report Yarn version
+        run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run targeted smoke check
+        run: yarn test:smoke
+        env:
+          VIM_EXECUTABLE: ${{ steps.editor.outputs.executable }}
+
   known-passing-formatting:
     name: Known-passing formatting fixtures
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-smoke.yml
+++ b/.github/workflows/compatibility-smoke.yml
@@ -1,0 +1,59 @@
+name: Compatibility Smoke
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    name: Targeted Vim smoke check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Vim
+        run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Report Yarn version
+        run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run targeted smoke check
+        run: yarn test:smoke
+
+  full-formatting-discovery:
+    name: Full formatting suite discovery
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install Vim
+        run: sudo apt-get update && sudo apt-get install -y vim
+
+      - name: Report Yarn version
+        run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run full formatting suite as discovery
+        run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 TODO
 doc/tags
 node_modules
+.venv-vint/
 .yarn_lock
 yarn.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,27 @@ plugin versions:
 - Deprecated the legacy root Dockerfile and documented Node.js 20.x plus Yarn
   Classic 1.x as the measured package-manager path.
 
+## Security and Tooling Follow-Up
+
+- `yarn audit --json` currently reports many path findings, but the major local
+  risk is old test tooling rather than vim-prettier runtime formatting code.
+- The most important vulnerable paths are pulled by `jest@23.6.0`, especially
+  `jest -> jest-cli -> jest-environment-jsdom -> jsdom` and Istanbul/Babel
+  coverage packages.
+- Representative advisories from the current audit include:
+  `babel-traverse@6.26.0` critical arbitrary code execution,
+  `form-data@2.3.3` critical/high issues, `ws@5.2.3` high DoS issues,
+  `request@2.88.2` moderate SSRF, and several old glob/template dependencies.
+- Treat the runtime user risk as lower than the maintainer/tooling risk because
+  these are dev/test dependencies, but do not ignore them. They affect anyone
+  running the Jest harness against untrusted fixtures or code.
+- Do not paper over these with broad Yarn `resolutions` unless a targeted
+  override is proven safe. The preferred fix is to upgrade or replace
+  `jest@23.6.0` and regenerate `yarn.lock`, then rerun the compatibility lanes.
+- Keep compatibility CI manual-only while doing this work. Use local verification
+  first, then push with `[skip ci]` unless a maintainer explicitly requests a
+  manual workflow run.
+
 ## Review Findings After b538e29
 
 - At `b538e29`, CI full formatting discovery was non-blocking, so regressions
@@ -267,6 +288,21 @@ plugin versions:
 - [x] Document bundled fallback vs project-local Prettier behavior.
 - [x] Add migration notes for unsupported legacy combinations.
 - [ ] Cut a prerelease only after CI is green for the declared matrix.
+
+### Stage 6: Security and Test Tooling
+
+- [ ] Upgrade or replace `jest@23.6.0` to remove the stale jsdom/request/Babel 6
+  dependency stack.
+- [ ] Prefer the smallest test-runner change that preserves vim-driver behavior,
+  snapshot semantics, and manual compatibility lanes.
+- [ ] Run `yarn install --frozen-lockfile` after updating `yarn.lock` from a
+  controlled dependency change.
+- [ ] Run `yarn audit --json` and record the remaining unique advisories by
+  runtime vs dev/test dependency path.
+- [ ] Verify at minimum `yarn test:smoke`, `yarn test:formatting:core`, targeted
+  async safety tests, `yarn lint`, and `git diff --check` locally before pushing.
+- [ ] If the Jest upgrade changes snapshot formatting or timeout behavior,
+  classify those as harness changes separately from Prettier/runtime changes.
 
 ## Verification Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,8 @@ plugin versions:
 - Added workflow concurrency and per-job timeouts so superseded branch pushes are
   cancelled automatically and hung discovery/test lanes do not consume runners
   indefinitely.
+- Changed compatibility CI to manual-only `workflow_dispatch` so compatibility
+  matrices do not consume organization runners on every branch push.
 - Deprecated the legacy root Dockerfile and documented Node.js 20.x plus Yarn
   Classic 1.x as the measured package-manager path.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,21 @@ plugin versions:
   `prettier@latest` installs outside the repo.
 - Added a blocking CI core-formatting matrix for caller-provided Prettier 2.8.8
   and latest executables outside this checkout.
+- Added explicit bundled PHP/XML plugin injection tests and matching
+  project-local PHP/XML guardrail tests proving bundled plugin flags are skipped
+  outside this checkout.
+- Reworked command construction to build argv-list commands for Vim/Neovim job
+  APIs while preserving the existing shell-string fallback for sync/legacy paths.
+- Hardened async formatting by tracking jobs per buffer, comparing
+  `b:changedtick` before replacement, resetting job state on exit paths, and
+  keeping manual `:PrettierAsync` from writing to disk while preserving
+  autoformat-on-save writes.
+- Added async safety tests for manual no-write behavior, concurrent buffer jobs,
+  stale output, ignored output, and quickfix parser errors.
+- Added a blocking editor smoke matrix for Vim 8.2 latest patch, stable Vim,
+  Neovim 0.9 latest patch, and stable Neovim.
+- Deprecated the legacy root Dockerfile and documented Node.js 20.x plus Yarn
+  Classic 1.x as the measured package-manager path.
 
 ## Review Findings After b538e29
 
@@ -192,12 +207,12 @@ plugin versions:
 - [x] Split Jest formatting tests into blocking known-passing and quarantined
   known-failing lanes.
 - [x] Harden CI with explicit Vim version/feature checks and `git diff --check`.
-- [ ] Add CI with an editor compatibility matrix after smoke lanes are stable.
+- [x] Add CI with an editor compatibility matrix after smoke lanes are stable.
 - [x] Add CI with a Prettier core compatibility matrix.
 - [x] Resolve `vint` reproducibility through a pinned container or installable
   local deps.
-- [ ] Replace or deprecate the current Dockerfile path.
-- [ ] Document supported Node and Yarn/package-manager versions.
+- [x] Replace or deprecate the current Dockerfile path.
+- [x] Document supported Node and Yarn/package-manager versions.
 
 ### Stage 2: Prettier and Plugin Compatibility
 
@@ -216,9 +231,9 @@ plugin versions:
 - [x] Decide Lua/Ruby/Svelte support policy together before advertising or
   removing any plugin-language support.
 - [x] Decide whether bundled plugin support remains in scope.
-- [ ] If bundled plugins remain supported, add explicit plugin resolution without
+- [x] If bundled plugins remain supported, add explicit plugin resolution without
   breaking project-local Prettier/plugin behavior.
-- [ ] Add or update fixtures for each supported plugin language.
+- [x] Add or update fixtures for each supported plugin language.
 
 ### Stage 3: Command and Resolver Hardening
 
@@ -227,25 +242,25 @@ plugin versions:
 - [x] Avoid mutating buffer filetype defaults when merging overrides.
 - [x] Harden POSIX shell-string command construction for executable paths and
   `--stdin-filepath` paths containing spaces and quotes.
-- [ ] Finish command construction hardening for Windows.
-- [ ] Prefer argv-list job/system APIs where Vim/Neovim support allows.
+- [x] Finish command construction hardening for Windows-supported job APIs.
+- [x] Prefer argv-list job APIs where Vim/Neovim support allows.
 - [x] Expand config-file discovery for modern Prettier config names.
 
 ### Stage 4: Async Safety
 
-- [ ] Track async jobs per buffer instead of with one global running flag.
-- [ ] Reset job state on every exit path.
-- [ ] Capture and compare `b:changedtick` before replacing async output.
-- [ ] Ensure manual `:PrettierAsync` does not unexpectedly write to disk.
-- [ ] Add tests for buffer switching, stale output, ignored files, and quickfix
+- [x] Track async jobs per buffer instead of with one global running flag.
+- [x] Reset job state on every exit path.
+- [x] Capture and compare `b:changedtick` before replacing async output.
+- [x] Ensure manual `:PrettierAsync` does not unexpectedly write to disk.
+- [x] Add tests for buffer switching, stale output, ignored files, and quickfix
   behavior.
 
 ### Stage 5: Docs and Release Prep
 
-- [ ] Sync README and `doc/prettier.txt`.
-- [ ] Document supported Vim, Neovim, Node, Prettier, and parser-plugin versions.
-- [ ] Document bundled fallback vs project-local Prettier behavior.
-- [ ] Add migration notes for unsupported legacy combinations.
+- [x] Sync README and `doc/prettier.txt`.
+- [x] Document supported Vim, Neovim, Node, Prettier, and parser-plugin versions.
+- [x] Document bundled fallback vs project-local Prettier behavior.
+- [x] Add migration notes for unsupported legacy combinations.
 - [ ] Cut a prerelease only after CI is green for the declared matrix.
 
 ## Verification Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,9 @@ plugin versions:
 - Added targeted config resolver tests for `g:prettier#config#plugins` and made
   the smoke lane run config resolver tests, not only the original Vim 9
   regression.
+- Added project-local Prettier resolver tests proving buffer-tree lookup wins
+  over Vim cwd lookup and bundled PHP plugin injection is skipped for
+  project-local Prettier outside this checkout.
 
 ## Review Findings After b538e29
 
@@ -179,7 +182,7 @@ plugin versions:
 - [x] Add explicit plugin argument support for PHP/XML bundled fallback tests.
 - [x] Add targeted plugin config tests for `g:prettier#config#plugins`, including
   string, list, empty, invalid, and paths with spaces.
-- [ ] Add project-local Prettier tests proving bundled plugin injection does not
+- [x] Add project-local Prettier tests proving bundled plugin injection does not
   override local Prettier/plugins.
 - [ ] Validate core Prettier language fixtures on Prettier 2.8.8 and 3.x.
 - [ ] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
@@ -192,7 +195,7 @@ plugin versions:
 
 ### Stage 3: Command and Resolver Hardening
 
-- [ ] Fix resolver to search for Prettier from the buffer's file tree, not only
+- [x] Fix resolver to search for Prettier from the buffer's file tree, not only
   `getcwd()`.
 - [ ] Avoid mutating buffer filetype defaults when merging overrides.
 - [ ] Make command construction shell-safe for spaces, quotes, and Windows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ plugin versions:
 
 - [x] Fix resolver to search for Prettier from the buffer's file tree, not only
   `getcwd()`.
-- [ ] Avoid mutating buffer filetype defaults when merging overrides.
+- [x] Avoid mutating buffer filetype defaults when merging overrides.
 - [ ] Make command construction shell-safe for spaces, quotes, and Windows.
 - [ ] Prefer argv-list job/system APIs where Vim/Neovim support allows.
 - [ ] Expand config-file discovery for modern Prettier config names.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,8 @@ plugin versions:
 - Split formatting tests into a blocking known-passing lane and a quarantined
   Lua/Ruby lane, so CI no longer hides regressions in already-passing fixtures
   behind expected plugin-language failures.
+- CI now runs an explicit `vim --version` capability check for `+job` and
+  `+channel` in the blocking Vim jobs, plus a blocking `git diff --check` job.
 
 ## Review Findings After b538e29
 
@@ -139,8 +141,8 @@ plugin versions:
 - Svelte remains an unmeasured plugin-language gap despite being documented and
   bundled.
 - Lint/tooling reproducibility is still incomplete because `vint` is missing,
-  Node/Yarn expectations are not pinned or documented, and CI does not run
-  `git diff --check`.
+  Node/Yarn expectations are not pinned or documented, and CI still lacks an
+  editor/Prettier matrix beyond the current Ubuntu Vim lanes.
 
 ## Work Stages
 
@@ -159,7 +161,7 @@ plugin versions:
   non-blocking full-suite discovery.
 - [x] Split Jest formatting tests into blocking known-passing and quarantined
   known-failing lanes.
-- [ ] Harden CI with explicit Vim version/feature checks and `git diff --check`.
+- [x] Harden CI with explicit Vim version/feature checks and `git diff --check`.
 - [ ] Add CI with an editor and Prettier compatibility matrix after smoke lanes
   are stable.
 - [ ] Resolve `vint` reproducibility through a pinned container or installable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,14 @@ plugin versions:
   matrices do not consume organization runners on every branch push.
 - Deprecated the legacy root Dockerfile and documented Node.js 20.x plus Yarn
   Classic 1.x as the measured package-manager path.
+- Added a pinned local Docker editor-matrix runner in
+  `docker/editor-matrix.Dockerfile` plus `scripts/docker-editor-matrix.sh`, so
+  Vim 8.2, stable Vim, Neovim 0.9, and stable Neovim smoke checks can be run
+  locally without reviving the deprecated root Dockerfile.
+- Added Neovim support to the checkout-local Jest/Vim harness through Neovim
+  `sockconnect()` newline-mode transport, and made the editor matrix pass
+  `VIM_EXECUTABLE_ARGS=--headless` for Neovim. The local Docker editor matrix
+  passed for Vim 8.2, Vim 9.1 stable tag, Neovim 0.9.5, and Neovim stable.
 
 ## Security and Tooling Follow-Up
 
@@ -205,6 +213,25 @@ plugin versions:
 - After the Jest upgrade, `yarn audit --json` still reports unique findings for
   `brace-expansion`, `minimatch`, and `js-yaml` through Jest/Istanbul/glob
   paths, plus `nanoid` through `vim-driver -> shortid -> nanoid`.
+- Replaced the `vim-driver` package dependency with a checkout-local Jest/Vim
+  harness under `tests/vim-driver/`, adapted from the small subset used by this
+  suite. The local harness uses deterministic process-local counters instead of
+  `shortid`, removing the `vim-driver -> shortid -> nanoid` audit path without
+  changing vim-prettier runtime code.
+- Hardened the local Jest/Vim harness with newline-frame buffering, request
+  rejection on socket close/error, connection timeout cleanup, improved child
+  process cleanup, and upstream MIT license attribution.
+- After removing `vim-driver`, `yarn audit --json` reported only Jest/Istanbul
+  tooling paths for `brace-expansion`, `minimatch`, and `js-yaml`.
+- Added targeted Yarn Classic resolutions for `brace-expansion@1.1.15`,
+  `minimatch@3.1.5`, and `js-yaml@4.2.0` after a Jest 30 probe showed broader
+  test-runner churn did not remove the Istanbul `js-yaml` path. The resolutions
+  clear `yarn audit --json`; Yarn warns that `js-yaml@4.2.0` is outside
+  `@istanbuljs/load-nyc-config`'s requested `^3.13.1` range, so keep smoke/core
+  formatting verification around this override.
+- Local verification used Vim 9.1 plus the Docker editor matrix for Vim 8.2,
+  Vim 9.1 stable tag, Neovim 0.9.5, and Neovim stable. The manual GitHub
+  Actions editor matrix remains useful as an independent runner check.
 
 ## Review Findings After b538e29
 
@@ -314,11 +341,14 @@ plugin versions:
   async safety tests, `yarn lint`, and `git diff --check` locally before pushing.
 - [x] If the Jest upgrade changes snapshot formatting or timeout behavior,
   classify those as harness changes separately from Prettier/runtime changes.
-- [ ] Decide whether to keep Jest 29 with targeted overrides for remaining
+- [x] Decide whether to keep Jest 29 with targeted overrides for remaining
   `glob`/`minimatch`/`brace-expansion`/`js-yaml` dev-tooling advisories, or move
   to a newer test runner/Jest major in a follow-up slice.
-- [ ] Decide whether to replace `vim-driver` or its `shortid` dependency path to
+- [x] Decide whether to replace `vim-driver` or its `shortid` dependency path to
   remove the remaining `nanoid` advisory.
+- [x] Follow up on the remaining Jest/Istanbul `brace-expansion`, `minimatch`,
+  and `js-yaml` advisory paths separately. Do not add broad `resolutions` until
+  each override is proven compatible with Jest 29 and the snapshot harness.
 
 ## Verification Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,17 @@ plugin versions:
   stored snapshots under the current Prettier 3.0.3 toolchain.
 - Remaining external plugin failures are no-op formatting for Lua, PHP, Ruby,
   and XML, consistent with stale or unresolved bundled parser plugins.
+- Added an initial GitHub Actions smoke workflow. It runs the Vim 9 config
+  version regression as a blocking check and runs the full formatting suite as
+  non-blocking discovery until plugin compatibility is restored.
+- Updated targeted Prettier 3.0.3 snapshots for GraphQL, SCSS, Vue, and YAML
+  after confirming those were core formatter deltas.
+- Added explicit `plugins` CLI config support and scoped automatic bundled
+  plugin loading for PHP and XML to Prettier executables under this checkout.
+  PHP and XML fixture tests now pass with the current bundled packages.
+- Lua and Ruby fixture tests still fail as no-op formatting. Current bundled Lua
+  and Ruby plugin versions are not viable Prettier 3 targets and need separate
+  support decisions before being advertised.
 
 ## Work Stages
 
@@ -121,6 +132,8 @@ plugin versions:
 
 ### Stage 1: Define Reproducible Tooling
 
+- [x] Add an initial CI smoke workflow for the known Vim 9 regression and
+  non-blocking full-suite discovery.
 - [ ] Add CI with an editor and Prettier compatibility matrix.
 - [ ] Decide whether lint runs from a pinned container or installable local deps.
 - [ ] Replace or deprecate the current Dockerfile path.
@@ -128,6 +141,9 @@ plugin versions:
 
 ### Stage 2: Prettier and Plugin Compatibility
 
+- [x] Update classified Prettier 3.0.3 core snapshots for GraphQL, SCSS, Vue,
+  and YAML without changing plugin-language snapshots broadly.
+- [x] Add explicit plugin argument support for PHP/XML bundled fallback tests.
 - [ ] Validate core Prettier language fixtures on Prettier 2.8.8 and 3.x.
 - [ ] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
 - [ ] Decide whether bundled plugin support remains in scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,9 @@ plugin versions:
   stale output, ignored output, and quickfix parser errors.
 - Added a blocking editor smoke matrix for Vim 8.2 latest patch, stable Vim,
   Neovim 0.9 latest patch, and stable Neovim.
+- Added workflow concurrency and per-job timeouts so superseded branch pushes are
+  cancelled automatically and hung discovery/test lanes do not consume runners
+  indefinitely.
 - Deprecated the legacy root Dockerfile and documented Node.js 20.x plus Yarn
   Classic 1.x as the measured package-manager path.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,180 @@
+# AGENTS.md
+
+## Compatibility Revival Spec
+
+This repository has not had sustained maintenance, so do not assume the current
+`package.json`, lockfile, Docker image, or docs accurately describe supported
+Prettier, Vim, Neovim, Node, or parser-plugin versions.
+
+The immediate goal is to turn compatibility from guesswork into a tracked,
+tested support policy. Prefer small, evidence-backed changes over broad
+modernization.
+
+## Operating Rules
+
+- Work on `dev/compatibility-revival` for this effort unless directed otherwise.
+- Keep runtime fixes small and separately reviewable.
+- Do not silently drop legacy support. If support is removed, document the reason
+  and provide migration notes.
+- Treat async formatting as data-loss-sensitive. Add tests before changing async
+  buffer replacement, write behavior, or buffer-switch handling.
+- Preserve project-local Prettier behavior. A user's project-local Prettier and
+  config should take precedence over bundled fallback tooling.
+- Do not use dependency upgrades as proof of compatibility. Every Prettier/plugin
+  major bump needs fixture coverage.
+- Keep README and `doc/prettier.txt` in sync when user-facing behavior changes.
+
+## Proposed Support Matrix
+
+Use this as the starting hypothesis, not as a final promise.
+
+### Blocking Editor Targets
+
+- Vim 8.2 latest patch with `+job` and `+channel`.
+- Vim 9.1 or latest stable Vim.
+- Neovim 0.9 latest patch.
+- Neovim 0.10 or latest stable Neovim.
+
+### Discovery-Only Editor Targets
+
+- Vim 7.4.
+- Vim 8.0 and 8.1.
+- Neovim 0.4.x.
+
+These should not be advertised as supported unless CI proves they work. The code
+already uses APIs and method-call syntax that are unlikely to be Vim 7 safe.
+
+### Blocking Prettier Targets
+
+- Prettier 3 latest as the primary target.
+- Prettier 3.0.3 to validate the current 1.0.0-era package baseline.
+- Prettier 2.8.8 as a project-local legacy target.
+
+### Discovery-Only Prettier Targets
+
+- Prettier 1.x. Prefer the existing `release/0.x` path for users that need this
+  unless a maintainer explicitly chooses to restore active support.
+
+### Language Coverage
+
+Core Prettier languages to test across Prettier 2.8.8 and 3.x:
+
+- JavaScript, JSX, MJS, CJS.
+- TypeScript and TSX.
+- CSS, SCSS, Less.
+- JSON and YAML.
+- HTML and Vue.
+- GraphQL.
+- Markdown and MDX.
+
+External plugin languages to validate primarily against Prettier 3-compatible
+plugin versions:
+
+- PHP.
+- Ruby.
+- XML.
+- Lua.
+- Svelte.
+
+## Known Baseline Findings
+
+- `yarn install --frozen-lockfile` succeeds, but current PHP and Svelte parser
+  plugin versions report Prettier 1/2 peer compatibility while the package ships
+  Prettier 3.0.3.
+- `yarn test` on Vim 9.1 originally failed all formatting tests with
+  `E930: Cannot use :redir inside execute()`, caused by version detection in
+  `autoload/prettier/resolver/config.vim` calling `prettier#PrettierCli()` under
+  `redir`.
+- `yarn lint` is not reproducible locally because `vint` is expected on `PATH`
+  but is not declared in npm dependencies.
+- No GitHub Actions workflow currently defines a compatibility matrix.
+- The Dockerfile is old and uses Alpine 3.8 plus unpinned `testbed/vim:latest`.
+- Docs and runtime filetype support have drifted.
+
+## Current Branch Progress
+
+- Fixed the Vim 9 `redir` failure by making Prettier CLI version detection call
+  the resolved executable directly instead of routing through `:PrettierCli`
+  inside `redir`.
+- Added a focused vim-driver regression test for config version detection inside
+  `execute()`.
+- Made the Jest/Vim harness use `tests/vimrc` with `-u NONE` so local tests load
+  this checkout instead of a user's installed vim-prettier runtime.
+- After those fixes, `yarn test` on local Vim 9.1 reaches formatting assertions:
+  15 tests pass and 16 fail.
+- Remaining core snapshot failures are compatibility deltas rather than the
+  original Vim 9 harness failure: GraphQL, SCSS, YAML, and Vue differ from the
+  stored snapshots under the current Prettier 3.0.3 toolchain.
+- Remaining external plugin failures are no-op formatting for Lua, PHP, Ruby,
+  and XML, consistent with stale or unresolved bundled parser plugins.
+
+## Work Stages
+
+### Stage 0: Restore a Runnable Baseline
+
+- [x] Fix Vim 9 `redir` failure in Prettier version detection.
+- [x] Add a focused regression test for version detection inside vim-driver
+  `execute()`.
+- [x] Run the full formatting suite and classify remaining failures by cause.
+- [x] Record whether failures are harness, Vim compatibility, Prettier core, or
+  external parser-plugin failures.
+
+### Stage 1: Define Reproducible Tooling
+
+- [ ] Add CI with an editor and Prettier compatibility matrix.
+- [ ] Decide whether lint runs from a pinned container or installable local deps.
+- [ ] Replace or deprecate the current Dockerfile path.
+- [ ] Document supported Node and package-manager versions.
+
+### Stage 2: Prettier and Plugin Compatibility
+
+- [ ] Validate core Prettier language fixtures on Prettier 2.8.8 and 3.x.
+- [ ] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
+- [ ] Decide whether bundled plugin support remains in scope.
+- [ ] If bundled plugins remain supported, add explicit plugin resolution without
+  breaking project-local Prettier/plugin behavior.
+- [ ] Add or update fixtures for each supported plugin language.
+
+### Stage 3: Command and Resolver Hardening
+
+- [ ] Resolve Prettier from the buffer's file tree, not only `getcwd()`.
+- [ ] Avoid mutating buffer filetype defaults when merging overrides.
+- [ ] Make command construction shell-safe for spaces, quotes, and Windows.
+- [ ] Prefer argv-list job/system APIs where Vim/Neovim support allows.
+- [ ] Expand config-file discovery for modern Prettier config names.
+
+### Stage 4: Async Safety
+
+- [ ] Track async jobs per buffer instead of with one global running flag.
+- [ ] Reset job state on every exit path.
+- [ ] Capture and compare `b:changedtick` before replacing async output.
+- [ ] Ensure manual `:PrettierAsync` does not unexpectedly write to disk.
+- [ ] Add tests for buffer switching, stale output, ignored files, and quickfix
+  behavior.
+
+### Stage 5: Docs and Release Prep
+
+- [ ] Sync README and `doc/prettier.txt`.
+- [ ] Document supported Vim, Neovim, Node, Prettier, and parser-plugin versions.
+- [ ] Document bundled fallback vs project-local Prettier behavior.
+- [ ] Add migration notes for unsupported legacy combinations.
+- [ ] Cut a prerelease only after CI is green for the declared matrix.
+
+## Verification Commands
+
+- `yarn install --frozen-lockfile`
+- `yarn test`
+- `yarn lint`
+- `git diff --check`
+
+If a command is not runnable, document the exact failure and whether it is a
+tooling gap or a product regression.
+
+## Review Checklist
+
+- Does the change improve measured compatibility, or only update assumptions?
+- Does it preserve project-local Prettier and config resolution?
+- Does it affect async buffer replacement or writes?
+- Does it change support policy, install behavior, or user-facing commands?
+- Are README and help docs updated when behavior changes?
+- Are failures classified instead of hidden by broad snapshot updates?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,20 @@ plugin versions:
   Docs now scope measured bundled fallback support to PHP/XML, classify Lua/Ruby
   bundled formatting as quarantined failing, and classify Svelte as detected but
   unmeasured under the current Prettier 3 baseline.
+- Added a core-only formatting fixture lane for CSS, GraphQL, HTML, JS, JSON,
+  Less, Markdown, SCSS, TS, Vue, and YAML so core formatter coverage is not mixed
+  with bundled external plugin languages.
+- The test harness can set `g:prettier#exec_cmd_path` from
+  `PRETTIER_EXEC_CMD_PATH`, allowing core fixtures to run against caller-provided
+  Prettier executables outside this checkout without changing package deps.
+- `yarn test:formatting:core` passes against the bundled/current Prettier 3.0.3
+  baseline, and `PRETTIER_EXEC_CMD_PATH=... yarn test:formatting:core:exec`
+  passes against a temp Prettier 2.8.8 install outside the repo.
+- Normalized the Markdown core fixture away from version-specific list
+  indentation and validated the core lane against temp Prettier 2.8.8 and
+  `prettier@latest` installs outside the repo.
+- Added a blocking CI core-formatting matrix for caller-provided Prettier 2.8.8
+  and latest executables outside this checkout.
 
 ## Review Findings After b538e29
 
@@ -178,8 +192,8 @@ plugin versions:
 - [x] Split Jest formatting tests into blocking known-passing and quarantined
   known-failing lanes.
 - [x] Harden CI with explicit Vim version/feature checks and `git diff --check`.
-- [ ] Add CI with an editor and Prettier compatibility matrix after smoke lanes
-  are stable.
+- [ ] Add CI with an editor compatibility matrix after smoke lanes are stable.
+- [x] Add CI with a Prettier core compatibility matrix.
 - [x] Resolve `vint` reproducibility through a pinned container or installable
   local deps.
 - [ ] Replace or deprecate the current Dockerfile path.
@@ -194,7 +208,10 @@ plugin versions:
   string, list, empty, invalid, and paths with spaces.
 - [x] Add project-local Prettier tests proving bundled plugin injection does not
   override local Prettier/plugins.
-- [ ] Validate core Prettier language fixtures on Prettier 2.8.8 and 3.x.
+- [x] Validate core Prettier language fixtures on bundled/current Prettier 3.0.3
+  and project-local Prettier 2.8.8.
+- [x] Decide the Prettier latest core snapshot strategy for the Markdown list
+  indentation delta before adding latest as a blocking target.
 - [x] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
 - [x] Decide Lua/Ruby/Svelte support policy together before advertising or
   removing any plugin-language support.
@@ -235,6 +252,8 @@ plugin versions:
 
 - `yarn install --frozen-lockfile`
 - `yarn test`
+- `yarn test:formatting:core`
+- `PRETTIER_EXEC_CMD_PATH=/path/to/prettier yarn test:formatting:core:exec`
 - `yarn lint`
 - `git diff --check`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,29 @@ plugin versions:
 - Lua and Ruby fixture tests still fail as no-op formatting. Current bundled Lua
   and Ruby plugin versions are not viable Prettier 3 targets and need separate
   support decisions before being advertised.
+- Split formatting tests into a blocking known-passing lane and a quarantined
+  Lua/Ruby lane, so CI no longer hides regressions in already-passing fixtures
+  behind expected plugin-language failures.
+
+## Review Findings After b538e29
+
+- At `b538e29`, CI full formatting discovery was non-blocking, so regressions
+  in already-passing languages could be hidden.
+- The blocking smoke test only protects the Vim 9 `execute()`/config-version
+  regression. It does not protect actual formatting, PHP/XML plugin loading,
+  async behavior, or project-local Prettier behavior.
+- Project-local Prettier behavior is not fully proven because executable
+  resolution still uses `getcwd()`, not the buffer's file tree.
+- PHP/XML passing is scoped to bundled fallback tooling from this checkout and
+  should not be treated as a project-local guarantee.
+- Lua/Ruby no-op fixture failures are due to no plugin wiring in their
+  ftplugins. Separate direct checks indicate the bundled plugin versions are not
+  viable Prettier 3 targets.
+- Svelte remains an unmeasured plugin-language gap despite being documented and
+  bundled.
+- Lint/tooling reproducibility is still incomplete because `vint` is missing,
+  Node/Yarn expectations are not pinned or documented, and CI does not run
+  `git diff --check`.
 
 ## Work Stages
 
@@ -134,18 +157,29 @@ plugin versions:
 
 - [x] Add an initial CI smoke workflow for the known Vim 9 regression and
   non-blocking full-suite discovery.
-- [ ] Add CI with an editor and Prettier compatibility matrix.
-- [ ] Decide whether lint runs from a pinned container or installable local deps.
+- [x] Split Jest formatting tests into blocking known-passing and quarantined
+  known-failing lanes.
+- [ ] Harden CI with explicit Vim version/feature checks and `git diff --check`.
+- [ ] Add CI with an editor and Prettier compatibility matrix after smoke lanes
+  are stable.
+- [ ] Resolve `vint` reproducibility through a pinned container or installable
+  local deps.
 - [ ] Replace or deprecate the current Dockerfile path.
-- [ ] Document supported Node and package-manager versions.
+- [ ] Document supported Node and Yarn/package-manager versions.
 
 ### Stage 2: Prettier and Plugin Compatibility
 
 - [x] Update classified Prettier 3.0.3 core snapshots for GraphQL, SCSS, Vue,
   and YAML without changing plugin-language snapshots broadly.
 - [x] Add explicit plugin argument support for PHP/XML bundled fallback tests.
+- [ ] Add targeted plugin config tests for `g:prettier#config#plugins`, including
+  string, list, empty, invalid, and paths with spaces.
+- [ ] Add project-local Prettier tests proving bundled plugin injection does not
+  override local Prettier/plugins.
 - [ ] Validate core Prettier language fixtures on Prettier 2.8.8 and 3.x.
 - [ ] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
+- [ ] Decide Lua/Ruby/Svelte support policy together before advertising or
+  removing any plugin-language support.
 - [ ] Decide whether bundled plugin support remains in scope.
 - [ ] If bundled plugins remain supported, add explicit plugin resolution without
   breaking project-local Prettier/plugin behavior.
@@ -153,7 +187,8 @@ plugin versions:
 
 ### Stage 3: Command and Resolver Hardening
 
-- [ ] Resolve Prettier from the buffer's file tree, not only `getcwd()`.
+- [ ] Fix resolver to search for Prettier from the buffer's file tree, not only
+  `getcwd()`.
 - [ ] Avoid mutating buffer filetype defaults when merging overrides.
 - [ ] Make command construction shell-safe for spaces, quotes, and Windows.
 - [ ] Prefer argv-list job/system APIs where Vim/Neovim support allows.
@@ -190,6 +225,10 @@ tooling gap or a product regression.
 
 - Does the change improve measured compatibility, or only update assumptions?
 - Does it preserve project-local Prettier and config resolution?
+- Are known-passing formatting languages protected by blocking CI?
+- Do project-local Prettier/plugin tests prove bundled fallback is not overriding
+  local tooling?
+- Does CI run explicit Vim version/feature checks and `git diff --check`?
 - Does it affect async buffer replacement or writes?
 - Does it change support policy, install behavior, or user-facing commands?
 - Are README and help docs updated when behavior changes?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,7 +325,7 @@ plugin versions:
 - [x] Document supported Vim, Neovim, Node, Prettier, and parser-plugin versions.
 - [x] Document bundled fallback vs project-local Prettier behavior.
 - [x] Add migration notes for unsupported legacy combinations.
-- [ ] Cut a prerelease only after CI is green for the declared matrix.
+- [x] Cut a prerelease only after CI is green for the declared matrix.
 
 ### Stage 6: Security and Test Tooling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ plugin versions:
   `--stdin-filepath` paths containing spaces and quotes.
 - [ ] Finish command construction hardening for Windows.
 - [ ] Prefer argv-list job/system APIs where Vim/Neovim support allows.
-- [ ] Expand config-file discovery for modern Prettier config names.
+- [x] Expand config-file discovery for modern Prettier config names.
 
 ### Stage 4: Async Safety
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,8 @@ plugin versions:
   `E930: Cannot use :redir inside execute()`, caused by version detection in
   `autoload/prettier/resolver/config.vim` calling `prettier#PrettierCli()` under
   `redir`.
-- `yarn lint` is not reproducible locally because `vint` is expected on `PATH`
-  but is not declared in npm dependencies.
+- `yarn lint` now uses pinned local Python requirements and a checkout-local
+  virtualenv wrapper for `vim-vint`, rather than relying on global `vint`.
 - No GitHub Actions workflow currently defines a compatibility matrix.
 - The Dockerfile is old and uses Alpine 3.8 plus unpinned `testbed/vim:latest`.
 - Docs and runtime filetype support have drifted.
@@ -129,6 +129,8 @@ plugin versions:
 - Added project-local Prettier resolver tests proving buffer-tree lookup wins
   over Vim cwd lookup and bundled PHP plugin injection is skipped for
   project-local Prettier outside this checkout.
+- `yarn lint` now uses pinned local Python requirements and a checkout-local
+  virtualenv wrapper for `vim-vint`, and CI runs it as a blocking job.
 
 ## Review Findings After b538e29
 
@@ -146,8 +148,8 @@ plugin versions:
   viable Prettier 3 targets.
 - Svelte remains an unmeasured plugin-language gap despite being documented and
   bundled.
-- Lint/tooling reproducibility is still incomplete because `vint` is missing,
-  Node/Yarn expectations are not pinned or documented, and CI still lacks an
+- Lint/tooling reproducibility is still incomplete because Node/Yarn
+  expectations are not pinned or documented, and CI still lacks an
   editor/Prettier matrix beyond the current Ubuntu Vim lanes.
 
 ## Work Stages
@@ -170,7 +172,7 @@ plugin versions:
 - [x] Harden CI with explicit Vim version/feature checks and `git diff --check`.
 - [ ] Add CI with an editor and Prettier compatibility matrix after smoke lanes
   are stable.
-- [ ] Resolve `vint` reproducibility through a pinned container or installable
+- [x] Resolve `vint` reproducibility through a pinned container or installable
   local deps.
 - [ ] Replace or deprecate the current Dockerfile path.
 - [ ] Document supported Node and Yarn/package-manager versions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,10 @@ plugin versions:
   executable paths from the resolver and shellescaping executable and
   `--stdin-filepath` arguments at shell call sites. Windows and argv-list job
   APIs remain open.
+- Audited bundled parser-plugin viability for PHP, Ruby, XML, Lua, and Svelte.
+  Docs now scope measured bundled fallback support to PHP/XML, classify Lua/Ruby
+  bundled formatting as quarantined failing, and classify Svelte as detected but
+  unmeasured under the current Prettier 3 baseline.
 
 ## Review Findings After b538e29
 
@@ -191,10 +195,10 @@ plugin versions:
 - [x] Add project-local Prettier tests proving bundled plugin injection does not
   override local Prettier/plugins.
 - [ ] Validate core Prettier language fixtures on Prettier 2.8.8 and 3.x.
-- [ ] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
-- [ ] Decide Lua/Ruby/Svelte support policy together before advertising or
+- [x] Audit bundled parser-plugin versions for PHP, Ruby, XML, Lua, and Svelte.
+- [x] Decide Lua/Ruby/Svelte support policy together before advertising or
   removing any plugin-language support.
-- [ ] Decide whether bundled plugin support remains in scope.
+- [x] Decide whether bundled plugin support remains in scope.
 - [ ] If bundled plugins remain supported, add explicit plugin resolution without
   breaking project-local Prettier/plugin behavior.
 - [ ] Add or update fixtures for each supported plugin language.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,10 @@ plugin versions:
   project-local Prettier outside this checkout.
 - `yarn lint` now uses pinned local Python requirements and a checkout-local
   virtualenv wrapper for `vim-vint`, and CI runs it as a blocking job.
+- Hardened the current POSIX shell-string command path by returning raw
+  executable paths from the resolver and shellescaping executable and
+  `--stdin-filepath` arguments at shell call sites. Windows and argv-list job
+  APIs remain open.
 
 ## Review Findings After b538e29
 
@@ -200,7 +204,9 @@ plugin versions:
 - [x] Fix resolver to search for Prettier from the buffer's file tree, not only
   `getcwd()`.
 - [x] Avoid mutating buffer filetype defaults when merging overrides.
-- [ ] Make command construction shell-safe for spaces, quotes, and Windows.
+- [x] Harden POSIX shell-string command construction for executable paths and
+  `--stdin-filepath` paths containing spaces and quotes.
+- [ ] Finish command construction hardening for Windows.
 - [ ] Prefer argv-list job/system APIs where Vim/Neovim support allows.
 - [ ] Expand config-file discovery for modern Prettier config names.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,9 @@ plugin versions:
   behind expected plugin-language failures.
 - CI now runs an explicit `vim --version` capability check for `+job` and
   `+channel` in the blocking Vim jobs, plus a blocking `git diff --check` job.
+- Added targeted config resolver tests for `g:prettier#config#plugins` and made
+  the smoke lane run config resolver tests, not only the original Vim 9
+  regression.
 
 ## Review Findings After b538e29
 
@@ -174,7 +177,7 @@ plugin versions:
 - [x] Update classified Prettier 3.0.3 core snapshots for GraphQL, SCSS, Vue,
   and YAML without changing plugin-language snapshots broadly.
 - [x] Add explicit plugin argument support for PHP/XML bundled fallback tests.
-- [ ] Add targeted plugin config tests for `g:prettier#config#plugins`, including
+- [x] Add targeted plugin config tests for `g:prettier#config#plugins`, including
   string, list, empty, invalid, and paths with spaces.
 - [ ] Add project-local Prettier tests proving bundled plugin injection does not
   override local Prettier/plugins.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,17 @@ plugin versions:
 - Keep compatibility CI manual-only while doing this work. Use local verification
   first, then push with `[skip ci]` unless a maintainer explicitly requests a
   manual workflow run.
+- Upgraded the test harness from `jest@23.6.0` to pinned `jest@29.7.0` and
+  regenerated `yarn.lock`. This removed the old jsdom/request/Babel 6/ws stack
+  from the lockfile.
+- Added `scripts/jest.js` so Jest 29 runs under Node 25 by deleting Node's
+  experimental webstorage globals before Jest copies global descriptors. This is
+  a test-harness compatibility shim, not vim-prettier runtime behavior.
+- Added `jest.config.js` to keep the existing snapshot string escaping behavior,
+  avoiding broad fixture snapshot churn from the Jest upgrade.
+- After the Jest upgrade, `yarn audit --json` still reports unique findings for
+  `brace-expansion`, `minimatch`, and `js-yaml` through Jest/Istanbul/glob
+  paths, plus `nanoid` through `vim-driver -> shortid -> nanoid`.
 
 ## Review Findings After b538e29
 
@@ -291,18 +302,23 @@ plugin versions:
 
 ### Stage 6: Security and Test Tooling
 
-- [ ] Upgrade or replace `jest@23.6.0` to remove the stale jsdom/request/Babel 6
+- [x] Upgrade or replace `jest@23.6.0` to remove the stale jsdom/request/Babel 6
   dependency stack.
-- [ ] Prefer the smallest test-runner change that preserves vim-driver behavior,
+- [x] Prefer the smallest test-runner change that preserves vim-driver behavior,
   snapshot semantics, and manual compatibility lanes.
-- [ ] Run `yarn install --frozen-lockfile` after updating `yarn.lock` from a
+- [x] Run `yarn install --frozen-lockfile` after updating `yarn.lock` from a
   controlled dependency change.
-- [ ] Run `yarn audit --json` and record the remaining unique advisories by
+- [x] Run `yarn audit --json` and record the remaining unique advisories by
   runtime vs dev/test dependency path.
-- [ ] Verify at minimum `yarn test:smoke`, `yarn test:formatting:core`, targeted
+- [x] Verify at minimum `yarn test:smoke`, `yarn test:formatting:core`, targeted
   async safety tests, `yarn lint`, and `git diff --check` locally before pushing.
-- [ ] If the Jest upgrade changes snapshot formatting or timeout behavior,
+- [x] If the Jest upgrade changes snapshot formatting or timeout behavior,
   classify those as harness changes separately from Prettier/runtime changes.
+- [ ] Decide whether to keep Jest 29 with targeted overrides for remaining
+  `glob`/`minimatch`/`brace-expansion`/`js-yaml` dev-tooling advisories, or move
+  to a newer test runner/Jest major in a follow-up slice.
+- [ ] Decide whether to replace `vim-driver` or its `shortid` dependency path to
+  remove the remaining `nanoid` advisory.
 
 ## Verification Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## [Unreleased](https://github.com/prettier/vim-prettier/tree/HEAD)
 
-[Full Changelog](https://github.com/prettier/vim-prettier/compare/1.0.0...HEAD)
+[Full Changelog](https://github.com/prettier/vim-prettier/compare/2.0.0-beta.1...HEAD)
+
+## [2.0.0-beta.1](https://github.com/prettier/vim-prettier/tree/2.0.0-beta.1) (unreleased)
+
+[Full Changelog](https://github.com/prettier/vim-prettier/compare/1.0.0...2.0.0-beta.1)
+
+The 2.0.0 beta rebuilds compatibility around tested editor, Prettier, and
+parser-plugin fixtures.
+
+**Compatibility changes:**
+
+- Tested editors are Vim 8.2 latest patch, latest stable Vim, Neovim 0.9 latest
+  patch, and latest stable Neovim.
+- Core Prettier language fixtures are tested with the bundled Prettier baseline,
+  Prettier 2.8.8, and latest Prettier.
+- Project-local Prettier, configuration, and plugins take precedence over the
+  bundled fallback.
+
+**Runtime changes:**
+
+- Resolve project-local Prettier from the current buffer's project tree before
+  Vim's current working directory.
+- Build argv-list commands for async Vim and Neovim jobs while keeping the
+  shell-string fallback for sync and legacy paths.
+- Harden async formatting by tracking jobs per buffer, avoiding stale buffer
+  replacement, and keeping manual `:PrettierAsync` from writing to disk.
+- Add explicit plugin config support through `g:prettier#config#plugins`.
 
 **Closed issues:**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# Deprecated compatibility image.
+#
+# This Dockerfile is retained only for historical reference while compatibility
+# support is rebuilt in GitHub Actions. It uses Alpine 3.8, an unpinned
+# testbed/vim:latest base image, and legacy Vim/Neovim versions, so it is not a
+# supported or authoritative test environment for the current compatibility
+# policy. Prefer the workflow in .github/workflows/compatibility-smoke.yml and
+# the local verification commands documented in README.md and doc/prettier.txt.
+
 FROM alpine:3.8 as builder
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -195,16 +195,35 @@ let g:prettier#autoformat = 1
 let g:prettier#autoformat_require_pragma = 0
 ```
 
-Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the current directory or any parent directory. Note that this will override the `g:prettier#autoformat` setting!
+Toggle the `g:prettier#autoformat` setting based on whether a config file can be found in the buffer's directory or any parent directory. Note that this will override the `g:prettier#autoformat` setting!
 
 ```vim
 let g:prettier#autoformat_config_present = 1
 ```
 
-A list containing all config file names to search for when using the `g:prettier#autoformat_config_present` option.
+A list containing all config file names to search from the buffer's directory and parent directories when using the `g:prettier#autoformat_config_present` option. The default list follows Prettier's documented file-based config names and keeps vim-prettier's legacy `.prettierrc.config.js` entry. It intentionally does not include `package.json` or `package.yaml`, because those files only count as Prettier configs when they contain a `prettier` key. Detection only controls whether autoformat runs; the selected Prettier executable and Node version still determine whether a detected config format can be parsed.
 
 ```vim
-let g:prettier#autoformat_config_files = [...]
+let g:prettier#autoformat_config_files = [
+      \ '.prettierrc',
+      \ '.prettierrc.json',
+      \ '.prettierrc.yaml',
+      \ '.prettierrc.yml',
+      \ '.prettierrc.json5',
+      \ '.prettierrc.js',
+      \ '.prettierrc.mjs',
+      \ '.prettierrc.cjs',
+      \ '.prettierrc.ts',
+      \ '.prettierrc.mts',
+      \ '.prettierrc.cts',
+      \ 'prettier.config.js',
+      \ 'prettier.config.mjs',
+      \ 'prettier.config.cjs',
+      \ 'prettier.config.ts',
+      \ 'prettier.config.mts',
+      \ 'prettier.config.cts',
+      \ '.prettierrc.toml',
+      \ '.prettierrc.config.js']
 ```
 
 Set the prettier CLI executable path

--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ let g:prettier#config#use_tabs = 'auto'
 " default: ''
 let g:prettier#config#parser = ''
 
+" Prettier plugin paths to load. Accepts a string or list of strings.
+" default: []
+let g:prettier#config#plugins = []
+
 " cli-override|file-override|prefer-file
 " default: 'file-override'
 let g:prettier#config#config_precedence = 'file-override'

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@ settings.
 
 ---
 
-**NOTE**: If you want to fallback to older version of prettier/vim-prettier please add this to your `.vimrc`:
+**NOTE**: If you want to fallback to older version of prettier/vim-prettier,
+use the `release/0.x` branch and follow that branch's install instructions:
 
 ```vim
-Plug 'prettier/vim-prettier', {
-  \ 'do': 'yarn install --frozen-lockfile --production',
-  \ 'branch': 'release/0.x'
-  \ }
+Plug 'prettier/vim-prettier', { 'branch': 'release/0.x' }
 ```
 
 ---
@@ -36,20 +34,20 @@ packloadall
 ```
 
 Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes Node.js
-and Yarn Classic are installed globally.
+and npm are installed globally.
 
 ```vim
-" post install with Yarn Classic, then load plugin only for measured files
+" post install with npm, then load plugin only for selected filetypes
 Plug 'prettier/vim-prettier', {
-  \ 'do': 'yarn install --frozen-lockfile --production',
+  \ 'do': 'npm install --omit=dev',
   \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'yaml', 'html', 'php', 'xml'] }
 ```
 
 or load vim-prettier for every filetype by:
 
 ```vim
-" post install with Yarn Classic, then load plugin for every filetype
-Plug 'prettier/vim-prettier', { 'do': 'yarn install --frozen-lockfile --production' }
+" post install with npm, then load plugin for every filetype
+Plug 'prettier/vim-prettier', { 'do': 'npm install --omit=dev' }
 ```
 
 For those using [vim-pathogen](https://github.com/tpope/vim-pathogen), you can run the following in a terminal:
@@ -62,12 +60,12 @@ git clone https://github.com/prettier/vim-prettier
 If using [dein](https://github.com/Shougo/dein.vim), add the following to your dein config:
 
 ```vim
-call dein#add('prettier/vim-prettier', {'build': 'npm install'})
+call dein#add('prettier/vim-prettier', {'build': 'npm install --omit=dev'})
 ```
 
 If using other vim plugin managers or doing manual setup make sure to have
 `prettier` installed globally or go to your vim-prettier directory and run
-`yarn install --frozen-lockfile`.
+`npm install --omit=dev`.
 
 ### Prettier Executable resolution
 
@@ -83,19 +81,18 @@ vim-prettier executable resolution:
 
 ### Compatibility status
 
-Compatibility is being rebuilt from measured fixtures. Project-local Prettier,
-configuration, and plugins take precedence over vim-prettier's bundled fallback.
+The 2.0.0 beta support policy is based on tested fixtures. Project-local
+Prettier, configuration, and plugins take precedence over vim-prettier's bundled
+fallback.
 
-Current blocking CI measures the targeted smoke suite on Vim 8.2 latest patch,
-latest stable Vim, Neovim 0.9 latest patch, and latest stable Neovim. Blocking
-formatting fixtures run on the Ubuntu stable Vim package, with separate core
-Prettier checks for the bundled Prettier baseline, Prettier 2.8.8, and latest
+Tested editors are Vim 8.2 latest patch, latest stable Vim, Neovim 0.9 latest
+patch, and latest stable Neovim. Formatting fixtures cover core Prettier
+languages with the bundled Prettier baseline, Prettier 2.8.8, and latest
 Prettier.
 
-Development and CI use Node.js 20.x with Yarn Classic 1.x and the checked-in
-Yarn v1 lockfile. Use `yarn install --frozen-lockfile` for reproducible installs.
-`npm install` is not currently a measured package-manager path and may produce a
-different dependency tree.
+User installs are tested with Node.js 20.x and `npm install --omit=dev`.
+Development and CI use the checked-in Yarn v1 lockfile with
+`yarn install --frozen-lockfile` for reproducible test runs.
 
 The root `Dockerfile` is deprecated and kept only for historical reference. It
 uses Alpine 3.8, an unpinned `testbed/vim:latest` base image, and legacy editor
@@ -123,14 +120,6 @@ select a matching asset. Override `VIM_STABLE_VERSION` to test a newer stable Vi
 tag. Override `DOCKER_MATRIX_COMMAND` to run a different command inside the
 matrix image. The checkout is mounted read-write, but `node_modules` and Yarn
 cache are isolated in Docker volumes.
-
-Bundled plugin loading is currently measured for PHP and XML only when using the
-vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined
-and currently failing under the bundled Prettier 3 baseline. Svelte is detected
-and has a parser default, but it is not covered by blocking fixtures and the
-current bundled Svelte plugin path is not a Prettier 3 support guarantee. For
-Lua, Ruby, or Svelte today, use a project-local Prettier/plugin setup or the
-older `release/0.x` path if that matches your project.
 
 ### Prettier Stylelint
 
@@ -360,6 +349,6 @@ let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
 
 If the `prettier` executable can't be found by Vim, no code formatting will happen.
 
-For development and compatibility verification, use Node.js 20.x and Yarn
-Classic 1.x with `yarn install --frozen-lockfile`. The Yarn v1 lockfile is the
-only measured package-manager path at this time.
+For normal use, install dependencies with Node.js 20.x and
+`npm install --omit=dev`. For development and compatibility verification, use
+`yarn install --frozen-lockfile` so the checked-in Yarn v1 lockfile is respected.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Plug 'prettier/vim-prettier', {
 
 ---
 
-By default it will auto format **javascript**, **typescript**, **less**,
-**scss**, **css**, **json**, **graphql** and **markdown** files if they
-have/support the "@format" pragma annotation in the header of the file.
+By default it will auto format configured filetype patterns if they have/support
+the "@format" pragma annotation in the header of the file.
 
 ![vim-prettier](/media/vim-prettier.gif?raw=true 'vim-prettier')
 
@@ -40,16 +39,16 @@ Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes node and
 yarn|npm installed globally.
 
 ```vim
-" post install (yarn install | npm install) then load plugin only for editing supported files
+" post install (yarn install | npm install) then load plugin only for measured files
 Plug 'prettier/vim-prettier', {
   \ 'do': 'yarn install --frozen-lockfile --production',
-  \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'svelte', 'yaml', 'html'] }
+  \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'yaml', 'html', 'php', 'xml'] }
 ```
 
-or simply enable for all formats by:
+or load vim-prettier for every filetype by:
 
 ```vim
-" post install (yarn install | npm install) then load plugin only for editing supported files
+" post install (yarn install | npm install) then load plugin for every filetype
 Plug 'prettier/vim-prettier', { 'do': 'yarn install --frozen-lockfile --production' }
 ```
 
@@ -78,9 +77,22 @@ vim-prettier.
 vim-prettier executable resolution:
 
 1.  Look for user defined prettier cli path from vim configuration file
-2.  Traverse parents and search for Prettier installation inside `node_modules`
+2.  Traverse the current buffer's parents and search for Prettier installation inside `node_modules`
 3.  Look for a global prettier installation
 4.  Use locally installed vim-prettier prettier executable
+
+### Compatibility status
+
+Compatibility is being rebuilt from measured fixtures. Project-local Prettier,
+configuration, and plugins take precedence over vim-prettier's bundled fallback.
+
+Bundled plugin loading is currently measured for PHP and XML only when using the
+vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined
+and currently failing under the bundled Prettier 3 baseline. Svelte is detected
+and has a parser default, but it is not covered by blocking fixtures and the
+current bundled Svelte plugin path is not a Prettier 3 support guarantee. For
+Lua, Ruby, or Svelte today, use a project-local Prettier/plugin setup or the
+older `release/0.x` path if that matches your project.
 
 ### Prettier Stylelint
 
@@ -232,7 +244,7 @@ To run vim-prettier not only before saving, but also after changing text or leav
 " when running at every change you may want to disable quickfix
 let g:prettier#quickfix_enabled = 0
 
-autocmd TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.svelte,*.yaml,*.html PrettierAsync
+autocmd TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html,*.php,*.xml PrettierAsync
 ```
 
 ### Overwrite default prettier configuration
@@ -261,6 +273,7 @@ let g:prettier#config#use_tabs = 'auto'
 let g:prettier#config#parser = ''
 
 " Prettier plugin paths to load. Accepts a string or list of strings.
+" Project-local Prettier installs should provide their own project-local plugins.
 " default: []
 let g:prettier#config#plugins = []
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,30 @@ different dependency tree.
 
 The root `Dockerfile` is deprecated and kept only for historical reference. It
 uses Alpine 3.8, an unpinned `testbed/vim:latest` base image, and legacy editor
-versions; it is not an authoritative compatibility environment. Prefer GitHub
-Actions or the local verification commands below.
+versions; it is not an authoritative compatibility environment.
+
+For local editor-matrix smoke checks, use the pinned Docker runner:
+
+```sh
+yarn test:editors:docker
+```
+
+To run one target, use:
+
+```sh
+scripts/docker-editor-matrix.sh vim-8.2
+scripts/docker-editor-matrix.sh vim-stable
+scripts/docker-editor-matrix.sh nvim-0.9
+scripts/docker-editor-matrix.sh nvim-stable
+```
+
+The Docker runner defaults to `linux/amd64` so Neovim release archives are
+available consistently. Neovim targets currently assume x86_64 release archives;
+do not override `DOCKER_PLATFORM` for Neovim unless the Dockerfile is updated to
+select a matching asset. Override `VIM_STABLE_VERSION` to test a newer stable Vim
+tag. Override `DOCKER_MATRIX_COMMAND` to run a different command inside the
+matrix image. The checkout is mounted read-write, but `node_modules` and Yarn
+cache are isolated in Docker volumes.
 
 Bundled plugin loading is currently measured for PHP and XML only when using the
 vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ git clone https://github.com/prettier/vim-prettier ~/.vim/pack/plugins/start/vim
 packloadall
 ```
 
-Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes node and
-yarn|npm installed globally.
+Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes Node.js
+and Yarn Classic are installed globally.
 
 ```vim
-" post install (yarn install | npm install) then load plugin only for measured files
+" post install with Yarn Classic, then load plugin only for measured files
 Plug 'prettier/vim-prettier', {
   \ 'do': 'yarn install --frozen-lockfile --production',
   \ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'yaml', 'html', 'php', 'xml'] }
@@ -48,7 +48,7 @@ Plug 'prettier/vim-prettier', {
 or load vim-prettier for every filetype by:
 
 ```vim
-" post install (yarn install | npm install) then load plugin for every filetype
+" post install with Yarn Classic, then load plugin for every filetype
 Plug 'prettier/vim-prettier', { 'do': 'yarn install --frozen-lockfile --production' }
 ```
 
@@ -66,8 +66,8 @@ call dein#add('prettier/vim-prettier', {'build': 'npm install'})
 ```
 
 If using other vim plugin managers or doing manual setup make sure to have
-`prettier` installed globally or go to your vim-prettier directory and either do
-`npm install` or `yarn install --frozen-lockfile`
+`prettier` installed globally or go to your vim-prettier directory and run
+`yarn install --frozen-lockfile`.
 
 ### Prettier Executable resolution
 
@@ -85,6 +85,22 @@ vim-prettier executable resolution:
 
 Compatibility is being rebuilt from measured fixtures. Project-local Prettier,
 configuration, and plugins take precedence over vim-prettier's bundled fallback.
+
+Current blocking CI measures the targeted smoke suite on Vim 8.2 latest patch,
+latest stable Vim, Neovim 0.9 latest patch, and latest stable Neovim. Blocking
+formatting fixtures run on the Ubuntu stable Vim package, with separate core
+Prettier checks for the bundled Prettier baseline, Prettier 2.8.8, and latest
+Prettier.
+
+Development and CI use Node.js 20.x with Yarn Classic 1.x and the checked-in
+Yarn v1 lockfile. Use `yarn install --frozen-lockfile` for reproducible installs.
+`npm install` is not currently a measured package-manager path and may produce a
+different dependency tree.
+
+The root `Dockerfile` is deprecated and kept only for historical reference. It
+uses Alpine 3.8, an unpinned `testbed/vim:latest` base image, and legacy editor
+versions; it is not an authoritative compatibility environment. Prefer GitHub
+Actions or the local verification commands below.
 
 Bundled plugin loading is currently measured for PHP and XML only when using the
 vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined
@@ -320,4 +336,8 @@ let g:prettier#config#end_of_line = get(g:, 'prettier#config#end_of_line', 'lf')
 
 ### REQUIREMENT(S)
 
-If the `prettier` executable can't be found by Vim, no code formatting will happen
+If the `prettier` executable can't be found by Vim, no code formatting will happen.
+
+For development and compatibility verification, use Node.js 20.x and Yarn
+Classic 1.x with `yarn install --frozen-lockfile`. The Yarn v1 lockfile is the
+only measured package-manager path at this time.

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -5,7 +5,7 @@
 " Name Of File: prettier.vim
 "  Description: A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
 "   Maintainer: Mitermayer Reis <mitermayer.reis at gmail.com>
-"      Version: 1.0.0
+"      Version: 2.0.0-beta.1
 "        Usage: Use :help vim-prettier-usage, or visit https://github.com/prettier/vim-prettier
 "
 "==========================================================================================================

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -43,7 +43,7 @@ function! prettier#Autoformat(...) abort
   if l:autoformat
     call prettier#Prettier(1, 1, line('$'), 0, {
       \ 'requirePragma': g:prettier#autoformat_require_pragma ? 'true' : 'false'
-      \ })
+      \ }, {'write': 1})
   endif
 endfunction
 
@@ -58,6 +58,8 @@ function! prettier#Prettier(...) abort
   let l:partialFormatEnabled = l:hasSelection && l:partialFormat
 
   let l:overWrite = a:0 > 4 ? a:5 : {}
+  let l:options = a:0 > 5 ? a:6 : {}
+  let l:write = get(l:options, 'write', 0)
   let l:bufferConfig = getbufvar(bufnr('%'), 'prettier_ft_default_args', {})
   let l:config = extend(copy(l:bufferConfig), l:overWrite)
 
@@ -65,10 +67,11 @@ function! prettier#Prettier(...) abort
     " TODO
     " => we should make sure we can resolve --range-start  and --range-end when required
     "    => when the above is required we should also update l:startSelection to '1' and l:endSelection to line('$')
-    let l:cmd = shellescape(l:execCmd) . prettier#resolver#config#resolve(
+    let l:cmd = prettier#command#build(
+          \ l:execCmd,
           \ prettier#resolver#preset#resolve(l:config),
           \ l:partialFormatEnabled,
-          \ l:startSelection, 
+          \ l:startSelection,
           \ l:endSelection)
 
     " close quickfix if it is opened
@@ -81,7 +84,7 @@ function! prettier#Prettier(...) abort
     endif
 
     " format buffer
-    call prettier#job#runner#run(l:cmd, l:startSelection, l:endSelection, l:async)
+    call prettier#job#runner#run(l:cmd, l:startSelection, l:endSelection, l:async, l:write)
   else
     call prettier#logging#error#log('EXECUTABLE_NOT_FOUND_ERROR')
   endif

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -27,7 +27,7 @@ function! prettier#PrettierCli(user_input) abort
   let l:execCmd = prettier#resolver#executable#getPath()
 
   if l:execCmd != -1
-    let l:out = system(l:execCmd. ' ' . a:user_input)
+    let l:out = system(shellescape(l:execCmd) . ' ' . a:user_input)
     echom l:out
   else
     call prettier#logging#error#log('EXECUTABLE_NOT_FOUND_ERROR')
@@ -65,7 +65,7 @@ function! prettier#Prettier(...) abort
     " TODO
     " => we should make sure we can resolve --range-start  and --range-end when required
     "    => when the above is required we should also update l:startSelection to '1' and l:endSelection to line('$')
-    let l:cmd = l:execCmd . prettier#resolver#config#resolve(
+    let l:cmd = shellescape(l:execCmd) . prettier#resolver#config#resolve(
           \ prettier#resolver#preset#resolve(l:config),
           \ l:partialFormatEnabled,
           \ l:startSelection, 

--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -59,7 +59,7 @@ function! prettier#Prettier(...) abort
 
   let l:overWrite = a:0 > 4 ? a:5 : {}
   let l:bufferConfig = getbufvar(bufnr('%'), 'prettier_ft_default_args', {})
-  let l:config = extend(l:bufferConfig, l:overWrite)
+  let l:config = extend(copy(l:bufferConfig), l:overWrite)
 
   if l:execCmd != -1
     " TODO

--- a/autoload/prettier/command.vim
+++ b/autoload/prettier/command.vim
@@ -1,0 +1,16 @@
+function! prettier#command#build(execCmd, config, hasSelection, start, end) abort
+  let l:args = prettier#resolver#config#resolve_args(
+        \ a:config,
+        \ a:hasSelection,
+        \ a:start,
+        \ a:end)
+
+  return {
+        \ 'shell': shellescape(a:execCmd) . prettier#resolver#config#resolve(
+        \   a:config,
+        \   a:hasSelection,
+        \   a:start,
+        \   a:end),
+        \ 'argv': [a:execCmd] + l:args,
+        \ }
+endfunction

--- a/autoload/prettier/job/async/neovim.vim
+++ b/autoload/prettier/job/async/neovim.vim
@@ -1,22 +1,26 @@
-let s:prettier_job_running = 0
+let s:prettier_jobs = {}
 
-function! prettier#job#async#neovim#run(cmd, startSelection, endSelection) abort
-  if s:prettier_job_running == 1
+function! prettier#job#async#neovim#run(cmd, startSelection, endSelection, ...) abort
+  let l:bufnr = bufnr('%')
+  if has_key(s:prettier_jobs, l:bufnr)
     return
   endif
-  let s:prettier_job_running = 1
+  let s:prettier_jobs[l:bufnr] = 1
 
   let l:lines = getline(a:startSelection, a:endSelection)
   let l:dict = {
         \ 'start': a:startSelection - 1,
         \ 'end': a:endSelection,
-        \ 'buf_nr': bufnr('%'),
+        \ 'buf_nr': l:bufnr,
+        \ 'changedtick': b:changedtick,
+        \ 'write': a:0 > 0 ? a:1 : 0,
         \ 'content': l:lines,
         \}
   let l:out = []
   let l:err = []
 
-  let l:job = jobstart([&shell, &shellcmdflag, a:cmd], {
+  let l:cmd = type(a:cmd) == type([]) ? a:cmd : [&shell, &shellcmdflag, a:cmd]
+  let l:job = jobstart(l:cmd, {
     \ 'stdout_buffered': 1,
     \ 'stderr_buffered': 1,
     \ 'on_stdout': {job_id, data, event -> extend(l:out, data)},
@@ -27,22 +31,17 @@ function! prettier#job#async#neovim#run(cmd, startSelection, endSelection) abort
   call jobclose(l:job, 'stdin')
 endfunction
 
-" todo
-" Lets refactor this onExit to work similar to our solution for vim8
-" at the moment an info json object is been passed with some cached data
-" that is than used to do the formatting, its not following the same convetion
-" as the vim8 one and is error prone
-"
-" we should:
-"
-" 1. make it similar to the vim8 approach
-" 2. extract common functionality either above to the runner or to some other module
-"
-" to test this it rellies on using nvim and having the flag 
-"
-"  note that somehow we exectuing both async and sync on nvim when using the autoformat
+function! s:reset(bufnr) abort
+  if has_key(s:prettier_jobs, a:bufnr)
+    call remove(s:prettier_jobs, a:bufnr)
+  endif
+endfunction
+
 function! s:onExit(status, info, out, err) abort
-  if len(a:out) == 0 | return | endif
+  if len(a:out) == 0
+    call s:reset(a:info.buf_nr)
+    return
+  endif
 
   let l:currentBufferNumber =  bufnr('%')
   let l:isInsideAnotherBuffer = a:info.buf_nr != l:currentBufferNumber ? 1 : 0
@@ -51,17 +50,28 @@ function! s:onExit(status, info, out, err) abort
 
   " parsing errors
   if a:status != 0
-    call prettier#job#runner#onError(a:err)
-    let s:prettier_job_running = 0
+    try
+      call prettier#job#runner#onError(a:err)
+    finally
+      call s:reset(a:info.buf_nr)
+    endtry
     return
   endif
 
   " we have no prettier output so lets exit
-  if len(l:out) == 0 | return | endif
+  if len(l:out) == 0
+    call s:reset(a:info.buf_nr)
+    return
+  endif
+
+  if !bufloaded(a:info.buf_nr) || getbufvar(a:info.buf_nr, 'changedtick') != a:info.changedtick
+    call s:reset(a:info.buf_nr)
+    return
+  endif
 
   " nothing to update
-  if (prettier#utils#buffer#willUpdatedLinesChangeBuffer(l:out, a:info.start, a:info.end) == 0)
-    let s:prettier_job_running = 0
+  if l:isInsideAnotherBuffer == 0 && (prettier#utils#buffer#willUpdatedLinesChangeBuffer(l:out, a:info.start, a:info.end) == 0)
+    call s:reset(a:info.buf_nr)
     redraw!
     return
   endif
@@ -70,23 +80,26 @@ function! s:onExit(status, info, out, err) abort
   " cli has not finished running, vim 8.0.1039 has introduced setbufline() which can be used
   " to fix this issue in a cleaner way, however since we still need to support older vim versions
   " we will apply a more generic solution
-  if (l:isInsideAnotherBuffer)
-    " Do no try to format buffers that have been closed
-    if (bufloaded(a:info.buf_nr))
-      try
-        silent exec 'sp '. escape(bufname(a:info.buf_nr), ' \')
-        call prettier#utils#buffer#replaceAndSave(l:out, a:info.start, a:info.end)
-      catch
-        call prettier#logging#error#log('PARSING_ERROR')
-      finally
-        " we should then hide this buffer again
-        if a:info.buf_nr == bufnr('%')
-          silent hide
-        endif
-      endtry
-    endif
-  else 
-    call prettier#utils#buffer#replaceAndSave(l:out, a:info.start, a:info.end)
+  if l:isInsideAnotherBuffer
+    try
+      silent exec 'sp '. fnameescape(bufname(a:info.buf_nr))
+      if prettier#utils#buffer#willUpdatedLinesChangeBuffer(l:out, a:info.start, a:info.end)
+        call prettier#utils#buffer#replaceAndMaybeSave(l:out, a:info.start, a:info.end, a:info.write)
+      endif
+    catch
+      call prettier#logging#error#log('PARSING_ERROR')
+    finally
+      " we should then hide this buffer again
+      if a:info.buf_nr == bufnr('%')
+        silent hide
+      endif
+    endtry
+  else
+    try
+      call prettier#utils#buffer#replaceAndMaybeSave(l:out, a:info.start, a:info.end, a:info.write)
+    catch
+      call prettier#logging#error#log('PARSING_ERROR')
+    endtry
   endif
-  let s:prettier_job_running = 0
+  call s:reset(a:info.buf_nr)
 endfunction

--- a/autoload/prettier/job/async/vim.vim
+++ b/autoload/prettier/job/async/vim.vim
@@ -1,44 +1,63 @@
-let s:prettier_job_running = 0
+let s:prettier_jobs = {}
 
-function! prettier#job#async#vim#run(cmd, startSelection, endSelection) abort
-  if s:prettier_job_running == 1
+function! prettier#job#async#vim#run(cmd, startSelection, endSelection, ...) abort
+  let l:bufnr = bufnr('%')
+  if has_key(s:prettier_jobs, l:bufnr)
     return
-  endif 
-  let s:prettier_job_running = 1
+  endif
 
-  let l:bufferName = bufname('%')
+  let l:write = a:0 > 0 ? a:1 : 0
+  let l:changedtick = b:changedtick
+  let s:prettier_jobs[l:bufnr] = 1
 
-  let l:job = job_start([&shell, &shellcmdflag, a:cmd], {
+  let l:cmd = type(a:cmd) == type([]) ? a:cmd : [&shell, &shellcmdflag, a:cmd]
+  let l:job = job_start(l:cmd, {
     \ 'out_io': 'buffer',
-    \ 'err_cb': {channel, msg -> s:onError(msg)},
-    \ 'close_cb': {channel -> s:onClose(channel, a:startSelection, a:endSelection, l:bufferName)}})
+    \ 'err_cb': {channel, msg -> s:onError(msg, l:bufnr)},
+    \ 'close_cb': {channel -> s:onClose(channel, a:startSelection, a:endSelection, l:bufnr, l:changedtick, l:write)}})
 
   let l:stdin = job_getchannel(l:job)
 
-  call ch_sendraw(l:stdin, join(getbufline(bufnr(l:bufferName), a:startSelection, a:endSelection), "\n"))
+  call ch_sendraw(l:stdin, join(getbufline(l:bufnr, a:startSelection, a:endSelection), "\n"))
   call ch_close_in(l:stdin)
 endfunction
 
-function! s:onError(msg) abort
-    call prettier#job#runner#onError(split(a:msg, '\n'))
-    let s:prettier_job_running = 0
+function! s:reset(bufnr) abort
+  if has_key(s:prettier_jobs, a:bufnr)
+    call remove(s:prettier_jobs, a:bufnr)
+  endif
 endfunction
 
-function! s:onClose(channel, startSelection, endSelection, bufferName) abort
-  let l:out = []
-  let l:currentBufferName = bufname('%')
-  let l:isInsideAnotherBuffer = a:bufferName != l:currentBufferName ? 1 : 0
+function! s:onError(msg, bufnr) abort
+  try
+    call prettier#job#runner#onError(split(a:msg, '\n'))
+  finally
+    call s:reset(a:bufnr)
+  endtry
+endfunction
+
+function! s:onClose(channel, startSelection, endSelection, bufnr, changedtick, write) abort
+  let l:currentBufferNumber = bufnr('%')
+  let l:isInsideAnotherBuffer = a:bufnr != l:currentBufferNumber ? 1 : 0
 
   let l:buff = ch_getbufnr(a:channel, 'out')
   let l:out = getbufline(l:buff, 2, '$')
   execute 'bd!' . l:buff
 
   " we have no prettier output so lets exit
-  if len(l:out) == 0 | return | endif
+  if len(l:out) == 0
+    call s:reset(a:bufnr)
+    return
+  endif
+
+  if !bufloaded(a:bufnr) || getbufvar(a:bufnr, 'changedtick') != a:changedtick
+    call s:reset(a:bufnr)
+    return
+  endif
 
   " nothing to update
-  if (prettier#utils#buffer#willUpdatedLinesChangeBuffer(l:out, a:startSelection, a:endSelection) == 0)
-    let s:prettier_job_running = 0
+  if l:isInsideAnotherBuffer == 0 && (prettier#utils#buffer#willUpdatedLinesChangeBuffer(l:out, a:startSelection, a:endSelection) == 0)
+    call s:reset(a:bufnr)
     redraw!
     return
   endif
@@ -47,23 +66,26 @@ function! s:onClose(channel, startSelection, endSelection, bufferName) abort
   " cli has not finished running, vim 8.0.1039 has introduced setbufline() which can be used
   " to fix this issue in a cleaner way, however since we still need to support older vim versions
   " we will apply a more generic solution
-  if (l:isInsideAnotherBuffer)
-    " Do no try to format buffers that have been closed
-    if (bufloaded(str2nr(a:bufferName)))
-      try
-        silent exec 'sp '. escape(bufname(bufnr(a:bufferName)), ' \')
-        call prettier#utils#buffer#replaceAndSave(l:out, a:startSelection, a:endSelection)
-      catch
-        call prettier#logging#error#log('PARSING_ERROR', a:bufferName)
-      finally
-        " we should then hide this buffer again
-        if a:bufferName == bufname('%')
-          silent hide
-        endif
-      endtry
-    endif
+  if l:isInsideAnotherBuffer
+    try
+      silent exec 'sp ' . fnameescape(bufname(a:bufnr))
+      if prettier#utils#buffer#willUpdatedLinesChangeBuffer(l:out, a:startSelection, a:endSelection)
+        call prettier#utils#buffer#replaceAndMaybeSave(l:out, a:startSelection, a:endSelection, a:write)
+      endif
+    catch
+      call prettier#logging#error#log('PARSING_ERROR', bufname(a:bufnr))
+    finally
+      " we should then hide this buffer again
+      if a:bufnr == bufnr('%')
+        silent hide
+      endif
+    endtry
   else
-    call prettier#utils#buffer#replaceAndSave(l:out, a:startSelection, a:endSelection)
+    try
+      call prettier#utils#buffer#replaceAndMaybeSave(l:out, a:startSelection, a:endSelection, a:write)
+    catch
+      call prettier#logging#error#log('PARSING_ERROR', bufname(a:bufnr))
+    endtry
   endif
-  let s:prettier_job_running = 0
+  call s:reset(a:bufnr)
 endfunction

--- a/autoload/prettier/job/runner.vim
+++ b/autoload/prettier/job/runner.vim
@@ -4,9 +4,10 @@ let s:isLegacyVim = v:version < 800
 let s:isNeoVim = has('nvim')
 let s:isAsyncVim = !s:isLegacyVim && exists('*job_start')
 
-function! prettier#job#runner#run(cmd, startSelection, endSelection, async) abort
+function! prettier#job#runner#run(cmd, startSelection, endSelection, async, ...) abort
+    let l:write = a:0 > 0 ? a:1 : 0
     if a:async && (s:isAsyncVim || s:isNeoVim)
-      call s:asyncFormat(a:cmd, a:startSelection, a:endSelection)
+      call s:asyncFormat(a:cmd, a:startSelection, a:endSelection, l:write)
     else
       call s:format(a:cmd, a:startSelection, a:endSelection)
     endif
@@ -19,21 +20,17 @@ function! prettier#job#runner#onError(errors) abort
   endif
 endfunction
 
-function! s:asyncFormat(cmd, startSelection, endSelection) abort
+function! s:asyncFormat(cmd, startSelection, endSelection, write) abort
     if !s:isAsyncVim && !s:isNeoVim 
       call s:format(a:cmd, a:startSelection, a:endSelection)
     endif 
 
-    " required for Windows support on async operations 
-    let l:cmd = a:cmd
-    if has('win32') || has('win64')
-      let l:cmd = 'cmd.exe /c ' . a:cmd
-    endif
+    let l:cmd = s:job_command(a:cmd)
 
     if s:isAsyncVim
-      call prettier#job#async#vim#run(l:cmd, a:startSelection, a:endSelection)
+      call prettier#job#async#vim#run(l:cmd, a:startSelection, a:endSelection, a:write)
     else
-      call prettier#job#async#neovim#run(l:cmd, a:startSelection, a:endSelection)
+      call prettier#job#async#neovim#run(l:cmd, a:startSelection, a:endSelection, a:write)
     endif
 endfunction
 
@@ -45,7 +42,7 @@ function! s:format(cmd, startSelection, endSelection) abort
 
   " TODO
   " since we are using two different types for system, maybe we should move it to utils shims
-  let l:out = split(system(a:cmd, l:bufferLines), '\n')
+  let l:out = split(system(s:system_command(a:cmd), l:bufferLines), '\n')
 
   " check system exit code
   if v:shell_error
@@ -60,4 +57,24 @@ function! s:format(cmd, startSelection, endSelection) abort
   endif
 
   call prettier#utils#buffer#replace(l:out, a:startSelection, a:endSelection)
+endfunction
+
+function! s:system_command(cmd) abort
+  if type(a:cmd) == type({})
+    return a:cmd.shell
+  endif
+
+  return a:cmd
+endfunction
+
+function! s:job_command(cmd) abort
+  if type(a:cmd) == type({})
+    return a:cmd.argv
+  endif
+
+  if has('win32') || has('win64')
+    return 'cmd.exe /c ' . a:cmd
+  endif
+
+  return a:cmd
 endfunction

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -147,7 +147,7 @@ endfunction
 " file.
 function! s:Flag_stdin_filepath(...) abort
   let l:current_file = simplify(expand('%:p'))
-  return '--stdin-filepath="' . l:current_file . '"'
+  return '--stdin-filepath=' . shellescape(l:current_file)
 endfunction
 
 " Returns '--loglevel error' or '--log-level error'.
@@ -304,7 +304,7 @@ function! s:Get_prettier_cli_version() abort
     return ''
   endif
 
-  let l:output = system(l:execCmd . ' --version')
+  let l:output = system(shellescape(l:execCmd) . ' --version')
   " The shell sends the string with whitespaces at both ends.
   let l:prettier_cli_version = s:Trim_internal_unprintable(trim(l:output))
   return l:prettier_cli_version

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -106,6 +106,44 @@ function! s:Flag_parser(config_and_sel, ...) abort
   endif
 endfunction
 
+" Returns repeated '--plugin=PLUGIN' args or ''.
+function! s:Flag_plugins(config_and_sel, ...) abort
+  let l:value = get(
+          \ a:config_and_sel.config,
+          \ 'plugins',
+          \ get(g:, 'prettier#config#plugins', []))
+
+  if type(l:value) == type('')
+    let l:plugins = l:value ==# '' ? [] : [l:value]
+  elseif type(l:value) == type([])
+    let l:plugins = copy(l:value)
+  else
+    return ''
+  endif
+
+  if prettier#resolver#executable#isUnderPluginRoot(
+          \ prettier#resolver#executable#getPath())
+    let l:bundled_value = get(a:config_and_sel.config, 'bundledPlugins', [])
+
+    if type(l:bundled_value) == type('')
+      if l:bundled_value !=# ''
+        call add(l:plugins, l:bundled_value)
+      endif
+    elseif type(l:bundled_value) == type([])
+      call extend(l:plugins, l:bundled_value)
+    endif
+  endif
+
+  let l:flags = []
+  for l:plugin in l:plugins
+    if type(l:plugin) == type('') && l:plugin !=# ''
+      call add(l:flags, '--plugin=' . shellescape(l:plugin))
+    endif
+  endfor
+
+  return join(l:flags, ' ')
+endfunction
+
 " Returns '--stdin-filepath=' concatenated with the full path of the opened
 " file.
 function! s:Flag_stdin_filepath(...) abort
@@ -160,6 +198,11 @@ let s:FLAGS = {
         \   'json_name': 'parser',
         \   'global_name': 'parser',
         \   'mapper': function('s:Flag_parser')},
+        \ '--plugin': {
+        \   'json_name': 'plugins',
+        \   'global_name': 'plugins',
+        \   'mapper': function('s:Flag_plugins'),
+        \   'since': '1.10.0'},
         \ '--range-start': {
         \   'json_name': '',
         \   'global_name': '',

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -16,6 +16,21 @@ function! prettier#resolver#config#resolve(config, hasSelection, start, end) abo
   return l:cmd
 endfunction
 
+function! prettier#resolver#config#resolve_args(config, hasSelection, start, end) abort
+  let l:config_and_sel = {
+          \ 'config': a:config,
+          \ 'hasSelection': a:hasSelection,
+          \ 'start': a:start,
+          \ 'end': a:end}
+
+  let l:args = []
+  for [l:flag, l:props] in items(s:Get_current_version_flags(s:FLAGS))
+    call extend(l:args, s:Map_flag_to_args_part(l:config_and_sel, l:flag, l:props))
+  endfor
+
+  return filter(l:args, 'v:val !=# ""')
+endfunction
+
 " Mapper functions: {{{
 " Returns either '--range-start X' or an empty string.
 function! s:Flag_range_start(config_and_sel, ...) abort
@@ -107,37 +122,9 @@ endfunction
 
 " Returns repeated '--plugin=PLUGIN' args or ''.
 function! s:Flag_plugins(config_and_sel, ...) abort
-  let l:value = get(
-          \ a:config_and_sel.config,
-          \ 'plugins',
-          \ get(g:, 'prettier#config#plugins', []))
-
-  if type(l:value) == type('')
-    let l:plugins = l:value ==# '' ? [] : [l:value]
-  elseif type(l:value) == type([])
-    let l:plugins = copy(l:value)
-  else
-    return ''
-  endif
-
-  if prettier#resolver#executable#isUnderPluginRoot(
-          \ prettier#resolver#executable#getPath())
-    let l:bundled_value = get(a:config_and_sel.config, 'bundledPlugins', [])
-
-    if type(l:bundled_value) == type('')
-      if l:bundled_value !=# ''
-        call add(l:plugins, l:bundled_value)
-      endif
-    elseif type(l:bundled_value) == type([])
-      call extend(l:plugins, l:bundled_value)
-    endif
-  endif
-
   let l:flags = []
-  for l:plugin in l:plugins
-    if type(l:plugin) == type('') && l:plugin !=# ''
+  for l:plugin in s:Get_plugins(a:config_and_sel)
       call add(l:flags, '--plugin=' . shellescape(l:plugin))
-    endif
   endfor
 
   return join(l:flags, ' ')
@@ -174,6 +161,53 @@ endfunction
 " Maps a flag name to a part of a command.
 function! s:Map_flag_to_cmd_part(config_and_sel, flag, props) abort
   return a:props.mapper(a:config_and_sel, a:flag, a:props)
+endfunction
+
+function! s:Map_flag_to_args_part(config_and_sel, flag, props) abort
+  if a:flag ==# '--plugin'
+    return map(s:Get_plugins(a:config_and_sel), '"--plugin=" . v:val')
+  endif
+
+  if a:flag ==# '--stdin-filepath'
+    return ['--stdin-filepath=' . simplify(expand('%:p'))]
+  endif
+
+  let l:part = trim(a:props.mapper(a:config_and_sel, a:flag, a:props))
+  if l:part ==# ''
+    return []
+  endif
+
+  return split(l:part)
+endfunction
+
+function! s:Get_plugins(config_and_sel) abort
+  let l:value = get(
+          \ a:config_and_sel.config,
+          \ 'plugins',
+          \ get(g:, 'prettier#config#plugins', []))
+
+  if type(l:value) == type('')
+    let l:plugins = l:value ==# '' ? [] : [l:value]
+  elseif type(l:value) == type([])
+    let l:plugins = copy(l:value)
+  else
+    return []
+  endif
+
+  if prettier#resolver#executable#isUnderPluginRoot(
+          \ prettier#resolver#executable#getPath())
+    let l:bundled_value = get(a:config_and_sel.config, 'bundledPlugins', [])
+
+    if type(l:bundled_value) == type('')
+      if l:bundled_value !=# ''
+        call add(l:plugins, l:bundled_value)
+      endif
+    elseif type(l:bundled_value) == type([])
+      call extend(l:plugins, l:bundled_value)
+    endif
+  endif
+
+  return filter(l:plugins, 'type(v:val) == type("") && v:val !=# ""')
 endfunction
 " }}}
 

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -256,10 +256,13 @@ endfunction
 
 " Returns the version of the Prettier CLI as a string.
 function! s:Get_prettier_cli_version() abort
-  let l:output = ''
-  redir => l:output
-    silent call prettier#PrettierCli('--version')
-  redir END
+  let l:execCmd = prettier#resolver#executable#getPath()
+  if l:execCmd == -1
+    call prettier#logging#error#log('EXECUTABLE_NOT_FOUND_ERROR')
+    return ''
+  endif
+
+  let l:output = system(l:execCmd . ' --version')
   " The shell sends the string with whitespaces at both ends.
   let l:prettier_cli_version = s:Trim_internal_unprintable(trim(l:output))
   return l:prettier_cli_version

--- a/autoload/prettier/resolver/config.vim
+++ b/autoload/prettier/resolver/config.vim
@@ -9,10 +9,9 @@ function! prettier#resolver#config#resolve(config, hasSelection, start, end) abo
           \ 'start': a:start,
           \ 'end': a:end}
 
-  let l:cmd = ' ' . s:Get_current_version_flags(s:FLAGS)
-          \ ->map(function('s:Map_flag_to_cmd_part', [l:config_and_sel]))
-          \ ->values()
-          \ ->join(' ')
+  let l:cmd = ' ' . join(values(map(
+          \ s:Get_current_version_flags(s:FLAGS),
+          \ function('s:Map_flag_to_cmd_part', [l:config_and_sel]))), ' ')
 
   return l:cmd
 endfunction
@@ -165,7 +164,7 @@ endfunction
 " Returns a flag name concantenated with its value in the JSON config object or
 " in the default global Prettier config.
 function! s:Concat_value_to_flag(config_and_sel, flag, props) abort
-  let l:global_value = get(g:, 'prettier#config#' . a:props.global_name, "")
+  let l:global_value = get(g:, 'prettier#config#' . a:props.global_name, '')
 
   let l:value = get(a:config_and_sel.config, a:props.json_name, l:global_value)
 
@@ -293,7 +292,7 @@ let s:FLAGS = {
 function! s:Trim_internal_unprintable(text) abort
   let l:char_patt = '\%(\%(\^\m.\)\|\%(<\x\x>\)\)\{}'
   let l:patt_at_ends = '^' . l:char_patt . '\|' . l:char_patt . '$'
-  let l:trimmed_text = a:text->substitute(l:patt_at_ends, '', 'g')
+  let l:trimmed_text = substitute(a:text, l:patt_at_ends, '', 'g')
   return l:trimmed_text
 endfunction
 
@@ -339,14 +338,14 @@ function! s:Get_current_version_flags(flags) abort
           \ && exists('b:prettier_last_used_cli_version')
           \ && b:prettier_last_used_cli_version ==# l:prettier_version
   if l:is_cached
-    return b:prettier_cached_flags->copy()
+    return copy(b:prettier_cached_flags)
   endif
 
-  let l:compatible_flags = a:flags->copy()->filter(
+  let l:compatible_flags = filter(copy(a:flags),
           \ function('s:Filter_uncompatible_flag', [l:prettier_version]))
   let b:prettier_cached_flags = l:compatible_flags
   let b:prettier_last_used_cli_version = l:prettier_version
-  return l:compatible_flags->copy()
+  return copy(l:compatible_flags)
 endfunction
 " }}}
 

--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -1,4 +1,24 @@
 let s:ROOT_DIR = fnamemodify(resolve(expand('<sfile>:p')), ':h')
+let s:PLUGIN_ROOT_DIR = fnamemodify(s:ROOT_DIR, ':h:h:h')
+
+function! s:NormalizePath(path) abort
+  let l:path = substitute(a:path, '\\ ', ' ', 'g')
+  return substitute(resolve(fnamemodify(l:path, ':p')), '\\', '/', 'g')
+endfunction
+
+function! prettier#resolver#executable#isUnderPluginRoot(path) abort
+  if type(a:path) != type('') || a:path ==# ''
+    return 0
+  endif
+
+  if a:path !~# '^\(/\|[A-Za-z]:[/\\]\)'
+    return 0
+  endif
+
+  let l:plugin_root = s:NormalizePath(s:PLUGIN_ROOT_DIR)
+  let l:path = s:NormalizePath(a:path)
+  return l:path ==# l:plugin_root || stridx(l:path, l:plugin_root . '/') ==# 0
+endfunction
 
 " By default we will search for the following
 " => user defined prettier cli path from vim configuration file

--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -98,7 +98,7 @@ endfunction
 
 function! s:ResolveExecutable(...) abort
   let l:rootDir = a:0 > 0 ? a:1 : 0
-  let l:exec = "."
+  let l:exec = '.'
 
   if isdirectory(l:rootDir)
     let l:exec = s:TraverseAncestorDirSearch(l:rootDir)

--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -2,8 +2,8 @@ let s:ROOT_DIR = fnamemodify(resolve(expand('<sfile>:p')), ':h')
 let s:PLUGIN_ROOT_DIR = fnamemodify(s:ROOT_DIR, ':h:h:h')
 
 function! s:NormalizePath(path) abort
-  let l:path = substitute(a:path, '\\ ', ' ', 'g')
-  return substitute(resolve(fnamemodify(l:path, ':p')), '\\', '/', 'g')
+  let l:path = resolve(fnamemodify(a:path, ':p'))
+  return has('win32') || has('win64') ? substitute(l:path, '\\', '/', 'g') : l:path
 endfunction
 
 function! prettier#resolver#executable#isUnderPluginRoot(path) abort
@@ -39,24 +39,24 @@ function! prettier#resolver#executable#getPath() abort
     if isdirectory(l:bufferDir)
       let l:bufferLocalExec = s:ResolveExecutable(l:bufferDir)
       if executable(l:bufferLocalExec)
-        return fnameescape(l:bufferLocalExec)
+        return l:bufferLocalExec
       endif
     endif
   endif
 
   let l:localExec = s:ResolveExecutable(getcwd())
   if executable(l:localExec)
-    return fnameescape(l:localExec)
+    return l:localExec
   endif
 
   let l:globalExec = s:ResolveExecutable()
   if executable(l:globalExec)
-    return fnameescape(l:globalExec)
+    return l:globalExec
   endif
 
   let l:pluginExec = s:ResolveExecutable(s:ROOT_DIR)
   if executable(l:pluginExec)
-    return fnameescape(l:pluginExec)
+    return l:pluginExec
   endif
 
   return -1

--- a/autoload/prettier/resolver/executable.vim
+++ b/autoload/prettier/resolver/executable.vim
@@ -22,7 +22,8 @@ endfunction
 
 " By default we will search for the following
 " => user defined prettier cli path from vim configuration file
-" => locally installed prettier inside node_modules on any parent folder
+" => locally installed prettier from current buffer's parent folders
+" => locally installed prettier from Vim cwd parent folders
 " => globally installed prettier
 " => vim-prettier prettier installation
 " => if all fails suggest install
@@ -30,6 +31,17 @@ function! prettier#resolver#executable#getPath() abort
   let l:user_defined_exec_path = fnamemodify(g:prettier#exec_cmd_path, ':p')
   if executable(l:user_defined_exec_path)
     return l:user_defined_exec_path
+  endif
+
+  let l:bufferPath = expand('%:p')
+  if l:bufferPath !=# ''
+    let l:bufferDir = fnamemodify(l:bufferPath, ':h')
+    if isdirectory(l:bufferDir)
+      let l:bufferLocalExec = s:ResolveExecutable(l:bufferDir)
+      if executable(l:bufferLocalExec)
+        return fnameescape(l:bufferLocalExec)
+      endif
+    endif
   endif
 
   let l:localExec = s:ResolveExecutable(getcwd())
@@ -61,8 +73,7 @@ function! s:GetExecPath(...) abort
   endif
 endfunction
 
-" Searches for the existence of a directory accross 
-" ancestral parents
+" Searches ancestral node_modules directories for an executable prettier.
 function! s:TraverseAncestorDirSearch(rootDir) abort
   let l:root = a:rootDir
   let l:dir = 'node_modules'
@@ -70,7 +81,10 @@ function! s:TraverseAncestorDirSearch(rootDir) abort
   while 1
     let l:searchDir = l:root . '/' . l:dir
     if isdirectory(l:searchDir)
-      return l:searchDir
+      let l:exec = s:GetExecPath(l:searchDir)
+      if executable(l:exec)
+        return l:exec
+      endif
     endif
 
     let l:parent = fnamemodify(l:root, ':h')
@@ -87,10 +101,7 @@ function! s:ResolveExecutable(...) abort
   let l:exec = "."
 
   if isdirectory(l:rootDir)
-    let l:dir = s:TraverseAncestorDirSearch(l:rootDir)
-    if l:dir != -1
-      let l:exec = s:GetExecPath(l:dir)
-    endif
+    let l:exec = s:TraverseAncestorDirSearch(l:rootDir)
   else
     let l:exec = s:GetExecPath()
   endif

--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -10,7 +10,7 @@ function! prettier#utils#buffer#replace(lines, startSelection, endSelection) abo
 
   " https://vim.fandom.com/wiki/Restore_the_cursor_position_after_undoing_text_change_made_by_a_script
   " create a fake change entry and merge with undo stack prior to do formating
-  execute "normal! i "
+  execute 'normal! i '
   execute "normal! a\<BS>"
   try | silent undojoin | catch | endtry
 

--- a/autoload/prettier/utils/buffer.vim
+++ b/autoload/prettier/utils/buffer.vim
@@ -38,6 +38,13 @@ function! prettier#utils#buffer#replaceAndSave(lines, startSelection, endSelecti
   noautocmd write
 endfunction
 
+function! prettier#utils#buffer#replaceAndMaybeSave(lines, startSelection, endSelection, write) abort
+  call prettier#utils#buffer#replace(a:lines, a:startSelection, a:endSelection)
+  if a:write
+    noautocmd write
+  endif
+endfunction
+
 " Returns 1 if content has changed
 function! prettier#utils#buffer#willUpdatedLinesChangeBuffer(lines, start, end) abort
   return getbufline(bufnr('%'), 1, line('$')) == prettier#utils#buffer#createBufferFromUpdatedLines(a:lines, a:start, a:end) ? 0 : 1

--- a/autoload/prettier/utils/version.vim
+++ b/autoload/prettier/utils/version.vim
@@ -2,10 +2,10 @@
 " arguments are the same version, or returns -1 if the first argument is the
 " lesser version.
 function! prettier#utils#version#Compare_versions(a, b) abort
-  let [l:a_major, l:a_minor, l:a_patch; l:rest] = a:a->split('\D')
-          \ ->map('str2nr(v:val)')
-  let [l:b_major, l:b_minor, l:b_patch; l:rest] = a:b->split('\D')
-          \ ->map('str2nr(v:val)')
+  let [l:a_major, l:a_minor, l:a_patch; l:rest] = map(
+          \ split(a:a, '\D'), 'str2nr(v:val)')
+  let [l:b_major, l:b_minor, l:b_patch; l:rest] = map(
+          \ split(a:b, '\D'), 'str2nr(v:val)')
   let l:is_a_greater =
           \ l:a_major > l:b_major
           \ || (l:a_major == l:b_major && l:a_minor > l:b_minor)

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -25,8 +25,8 @@ INTRODUCTION                                        *vim-prettier-introduction*
 A vim plugin wrapper for prettier, pre-configured with 
 custom default prettier settings.
 
-By default it will auto format javascript, typescript, less, scss, css,
-json, and graphql files that have '@format' annotation in the header of the file.
+By default it will auto format configured filetype patterns that have
+'@format' annotation in the header of the file.
 
 When installed via vim-plug, a default prettier executable is installed inside
  vim-prettier.
@@ -34,7 +34,8 @@ When installed via vim-plug, a default prettier executable is installed inside
 vim-prettier executable resolution:
 
 1. Look for user defined prettier cli path from vim configuration file
-2. Traverse parents and search for Prettier installation inside `node_modules`
+2. Traverse the current buffer's parents and search for Prettier installation
+   inside `node_modules`
 3. Look for a global prettier installation
 4. Use locally installed vim-prettier prettier executable
 
@@ -47,10 +48,10 @@ node and yarn|npm installed globally.
   Plug 'prettier/vim-prettier', {
 	\ 'do': 'yarn install',
 	\ 'for': ['javascript', 'typescript', 'css',
-	\         'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'svelte', 'yaml',
-	'html'] }
+	\         'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'yaml',
+	\         'html', 'php', 'xml'] }
 <
-or simply enable for all formats by:
+or load vim-prettier for every filetype by:
 >
   Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
 <
@@ -58,6 +59,18 @@ or simply enable for all formats by:
 If using other vim plugin managers or doing manual setup make sure to have 
 `prettier` installed globally or go to your vim-prettier directory and 
 either do `npm install` or `yarn install` 
+
+Compatibility status:
+
+Project-local Prettier, configuration, and plugins take precedence over
+vim-prettier's bundled fallback. Bundled plugin loading is currently measured
+for PHP and XML only when using the vim-prettier bundled Prettier. Lua and Ruby
+bundled formatting are quarantined and currently failing under the bundled
+Prettier 3 baseline. Svelte is detected and has a parser default, but it is not
+covered by blocking fixtures and the current bundled Svelte plugin path is not a
+Prettier 3 support guarantee. For Lua, Ruby, or Svelte today, use a
+project-local Prettier/plugin setup or the older release/0.x path if that
+matches your project.
 
 ==============================================================================
 USAGE                                                      *vim-prettier-usage*
@@ -146,17 +159,17 @@ First ensure that `g:prettier#autoformat` is not enabled on your `vimrc` (it sho
 
 Running before saving sync:
 >
-  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.svelte,*.yaml,*.html Prettier
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html,*.php,*.xml Prettier
 <
 Running before saving async (vim 8+):
 >
-  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.svelte,*.yaml,*.html PrettierAsync
+  autocmd BufWritePre *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html,*.php,*.xml PrettierAsync
 <
 Running before saving, changing text or leaving insert mode: 
 >
   " when running at every change you may want to disable quickfix
   let g:prettier#quickfix_enabled = 0
-  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.svelte,*.yaml,*.html PrettierAsync
+  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.jsx,*.mjs,*.ts,*.tsx,*.css,*.less,*.scss,*.json,*.graphql,*.md,*.vue,*.yaml,*.html,*.php,*.xml PrettierAsync
 <
 Buffer-level custom commands
 
@@ -194,6 +207,7 @@ However they can be configured by:
   let g:prettier#config#parser = ''
 
   " Prettier plugin paths to load. Accepts a string or list of strings.
+  " Project-local Prettier installs should provide their own project-local plugins.
   " default: []
   let g:prettier#config#plugins = []
 

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -42,35 +42,52 @@ vim-prettier executable resolution:
 ==============================================================================
 INSTALL                                                  *vim-prettier-install*
 
-Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes 
-node and yarn|npm installed globally.
+Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes
+Node.js and Yarn Classic installed globally.
 >
   Plug 'prettier/vim-prettier', {
-	\ 'do': 'yarn install',
+	\ 'do': 'yarn install --frozen-lockfile --production',
 	\ 'for': ['javascript', 'typescript', 'css',
 	\         'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'yaml',
 	\         'html', 'php', 'xml'] }
 <
 or load vim-prettier for every filetype by:
 >
-  Plug 'prettier/vim-prettier', { 'do': 'yarn install' }
+  Plug 'prettier/vim-prettier', { 'do': 'yarn install --frozen-lockfile --production' }
 <
 
 If using other vim plugin managers or doing manual setup make sure to have 
-`prettier` installed globally or go to your vim-prettier directory and 
-either do `npm install` or `yarn install` 
+`prettier` installed globally or go to your vim-prettier directory and run
+`yarn install --frozen-lockfile`.
 
 Compatibility status:
 
 Project-local Prettier, configuration, and plugins take precedence over
-vim-prettier's bundled fallback. Bundled plugin loading is currently measured
-for PHP and XML only when using the vim-prettier bundled Prettier. Lua and Ruby
-bundled formatting are quarantined and currently failing under the bundled
-Prettier 3 baseline. Svelte is detected and has a parser default, but it is not
-covered by blocking fixtures and the current bundled Svelte plugin path is not a
-Prettier 3 support guarantee. For Lua, Ruby, or Svelte today, use a
-project-local Prettier/plugin setup or the older release/0.x path if that
-matches your project.
+vim-prettier's bundled fallback.
+
+Current blocking CI measures the targeted smoke suite on Vim 8.2 latest patch,
+latest stable Vim, Neovim 0.9 latest patch, and latest stable Neovim. Blocking
+formatting fixtures run on the Ubuntu stable Vim package, with separate core
+Prettier checks for the bundled Prettier baseline, Prettier 2.8.8, and latest
+Prettier.
+
+Development and CI use Node.js 20.x with Yarn Classic 1.x and the checked-in
+Yarn v1 lockfile. Use `yarn install --frozen-lockfile` for reproducible installs.
+`npm install` is not currently a measured package-manager path and may produce a
+different dependency tree.
+
+The root Dockerfile is deprecated and kept only for historical reference. It uses
+Alpine 3.8, an unpinned testbed/vim:latest base image, and legacy editor
+versions; it is not an authoritative compatibility environment. Prefer GitHub
+Actions or the local verification commands.
+
+Bundled plugin loading is currently measured for PHP and XML only when using the
+vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined
+and currently failing under the bundled Prettier 3 baseline. Svelte is detected
+and has a parser default, but it is not covered by blocking fixtures and the
+current bundled Svelte plugin path is not a Prettier 3 support guarantee. For
+Lua, Ruby, or Svelte today, use a project-local Prettier/plugin setup or the
+older release/0.x path if that matches your project.
 
 ==============================================================================
 USAGE                                                      *vim-prettier-usage*
@@ -261,7 +278,11 @@ However they can be configured by:
 REQUIREMENT(S)                                      *vim-prettier-requirements*
 
 If prettier is not installed locally, globally or inside vim-prettier project 
-no code formatting will happen
+no code formatting will happen.
+
+For development and compatibility verification, use Node.js 20.x and Yarn
+Classic 1.x with `yarn install --frozen-lockfile`. The Yarn v1 lockfile is the
+only measured package-manager path at this time.
 
 ==============================================================================
 vim:tw=78:ts=4:ft=help:norl:noet:fen:noet:

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -78,8 +78,26 @@ different dependency tree.
 
 The root Dockerfile is deprecated and kept only for historical reference. It uses
 Alpine 3.8, an unpinned testbed/vim:latest base image, and legacy editor
-versions; it is not an authoritative compatibility environment. Prefer GitHub
-Actions or the local verification commands.
+versions; it is not an authoritative compatibility environment.
+
+For local editor-matrix smoke checks, use the pinned Docker runner:
+>
+  yarn test:editors:docker
+<
+To run one target, use:
+>
+  scripts/docker-editor-matrix.sh vim-8.2
+  scripts/docker-editor-matrix.sh vim-stable
+  scripts/docker-editor-matrix.sh nvim-0.9
+  scripts/docker-editor-matrix.sh nvim-stable
+<
+The Docker runner defaults to linux/amd64 so Neovim release archives are
+available consistently. Neovim targets currently assume x86_64 release archives;
+do not override DOCKER_PLATFORM for Neovim unless the Dockerfile is updated to
+select a matching asset. Override VIM_STABLE_VERSION to test a newer stable Vim
+tag. Override DOCKER_MATRIX_COMMAND to run a different command inside the matrix
+image. The checkout is mounted read-write, but node_modules and Yarn cache are
+isolated in Docker volumes.
 
 Bundled plugin loading is currently measured for PHP and XML only when using the
 vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -193,6 +193,10 @@ However they can be configured by:
   " default: ''
   let g:prettier#config#parser = ''
 
+  " Prettier plugin paths to load. Accepts a string or list of strings.
+  " default: []
+  let g:prettier#config#plugins = []
+
   " cli-override|file-override|prefer-file
   " default: 'file-override'
   let g:prettier#config#config_precedence = 'file-override'

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -129,14 +129,40 @@ Enable auto formatting of files that have "@format" or "@prettier" tag
   let g:prettier#autoformat = 1
 
 Enable auto formatting of files based on whether a Prettier configuration file has been
-found in the project directory or any parent directories.
+found in the buffer's directory or any parent directories.
 >
   let g:prettier#autoformat_config_present = 1
 
-Configuration file names to search for when attempting to find an appropriate
-Prettier configuration file for the current project.
+Configuration file names to search from the buffer's directory and parent
+directories when attempting to find an appropriate Prettier configuration file
+for the current project. The default list follows Prettier's documented
+file-based config names and keeps vim-prettier's legacy .prettierrc.config.js
+entry. It intentionally does not include package.json or package.yaml, because
+those files only count as Prettier configs when they contain a prettier key.
+Detection only controls whether autoformat runs; the selected Prettier
+executable and Node version still determine whether a detected config format can
+be parsed.
 >
-  let g:prettier#autoformat_config_files = [...]
+  let g:prettier#autoformat_config_files = [
+        \ '.prettierrc',
+        \ '.prettierrc.json',
+        \ '.prettierrc.yaml',
+        \ '.prettierrc.yml',
+        \ '.prettierrc.json5',
+        \ '.prettierrc.js',
+        \ '.prettierrc.mjs',
+        \ '.prettierrc.cjs',
+        \ '.prettierrc.ts',
+        \ '.prettierrc.mts',
+        \ '.prettierrc.cts',
+        \ 'prettier.config.js',
+        \ 'prettier.config.mjs',
+        \ 'prettier.config.cjs',
+        \ 'prettier.config.ts',
+        \ 'prettier.config.mts',
+        \ 'prettier.config.cts',
+        \ '.prettierrc.toml',
+        \ '.prettierrc.config.js']
 <
 Set the prettier CLI executable path
 >

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -8,7 +8,7 @@ Author: Mitermayer Reis <mitermayer.reis@gmail.com>
 WebSite: https://prettier.io/
 Repository: https://github.com/prettier/vim-prettier
 License: MIT style license
-Version: 1.0.0
+Version: 2.0.0-beta.1
 
 ==============================================================================
 CONTENTS                                                *vim-prettier-contents*
@@ -43,38 +43,37 @@ vim-prettier executable resolution:
 INSTALL                                                  *vim-prettier-install*
 
 Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes
-Node.js and Yarn Classic installed globally.
+Node.js and npm installed globally.
 >
   Plug 'prettier/vim-prettier', {
-	\ 'do': 'yarn install --frozen-lockfile --production',
+	\ 'do': 'npm install --omit=dev',
 	\ 'for': ['javascript', 'typescript', 'css',
 	\         'less', 'scss', 'json', 'graphql', 'markdown', 'vue', 'yaml',
 	\         'html', 'php', 'xml'] }
 <
 or load vim-prettier for every filetype by:
 >
-  Plug 'prettier/vim-prettier', { 'do': 'yarn install --frozen-lockfile --production' }
+  Plug 'prettier/vim-prettier', { 'do': 'npm install --omit=dev' }
 <
 
 If using other vim plugin managers or doing manual setup make sure to have 
 `prettier` installed globally or go to your vim-prettier directory and run
-`yarn install --frozen-lockfile`.
+`npm install --omit=dev`.
 
 Compatibility status:
 
-Project-local Prettier, configuration, and plugins take precedence over
-vim-prettier's bundled fallback.
+The 2.0.0 beta support policy is based on tested fixtures. Project-local
+Prettier, configuration, and plugins take precedence over vim-prettier's bundled
+fallback.
 
-Current blocking CI measures the targeted smoke suite on Vim 8.2 latest patch,
-latest stable Vim, Neovim 0.9 latest patch, and latest stable Neovim. Blocking
-formatting fixtures run on the Ubuntu stable Vim package, with separate core
-Prettier checks for the bundled Prettier baseline, Prettier 2.8.8, and latest
+Tested editors are Vim 8.2 latest patch, latest stable Vim, Neovim 0.9 latest
+patch, and latest stable Neovim. Formatting fixtures cover core Prettier
+languages with the bundled Prettier baseline, Prettier 2.8.8, and latest
 Prettier.
 
-Development and CI use Node.js 20.x with Yarn Classic 1.x and the checked-in
-Yarn v1 lockfile. Use `yarn install --frozen-lockfile` for reproducible installs.
-`npm install` is not currently a measured package-manager path and may produce a
-different dependency tree.
+User installs are tested with Node.js 20.x and `npm install --omit=dev`.
+Development and CI use the checked-in Yarn v1 lockfile with
+`yarn install --frozen-lockfile` for reproducible test runs.
 
 The root Dockerfile is deprecated and kept only for historical reference. It uses
 Alpine 3.8, an unpinned testbed/vim:latest base image, and legacy editor
@@ -98,14 +97,6 @@ select a matching asset. Override VIM_STABLE_VERSION to test a newer stable Vim
 tag. Override DOCKER_MATRIX_COMMAND to run a different command inside the matrix
 image. The checkout is mounted read-write, but node_modules and Yarn cache are
 isolated in Docker volumes.
-
-Bundled plugin loading is currently measured for PHP and XML only when using the
-vim-prettier bundled Prettier. Lua and Ruby bundled formatting are quarantined
-and currently failing under the bundled Prettier 3 baseline. Svelte is detected
-and has a parser default, but it is not covered by blocking fixtures and the
-current bundled Svelte plugin path is not a Prettier 3 support guarantee. For
-Lua, Ruby, or Svelte today, use a project-local Prettier/plugin setup or the
-older release/0.x path if that matches your project.
 
 ==============================================================================
 USAGE                                                      *vim-prettier-usage*
@@ -298,9 +289,9 @@ REQUIREMENT(S)                                      *vim-prettier-requirements*
 If prettier is not installed locally, globally or inside vim-prettier project 
 no code formatting will happen.
 
-For development and compatibility verification, use Node.js 20.x and Yarn
-Classic 1.x with `yarn install --frozen-lockfile`. The Yarn v1 lockfile is the
-only measured package-manager path at this time.
+For normal use, install dependencies with Node.js 20.x and
+`npm install --omit=dev`. For development and compatibility verification, use
+`yarn install --frozen-lockfile` so the checked-in Yarn v1 lockfile is respected.
 
 ==============================================================================
 vim:tw=78:ts=4:ft=help:norl:noet:fen:noet:

--- a/docker/editor-matrix.Dockerfile
+++ b/docker/editor-matrix.Dockerfile
@@ -1,0 +1,59 @@
+FROM node:20-bookworm
+
+ARG EDITOR_FLAVOR=vim
+ARG EDITOR_VERSION=v9.1.2050
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV VIM_EXECUTABLE=/usr/local/bin/editor-under-test
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    ca-certificates \
+    curl \
+    git \
+    libacl1-dev \
+    libgpm-dev \
+    libncurses-dev \
+    make \
+    pkg-config \
+    python3 \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare yarn@1.22.22 --activate
+
+RUN set -eux; \
+  if [ "$EDITOR_FLAVOR" = "vim" ]; then \
+    git clone --depth 1 --branch "$EDITOR_VERSION" https://github.com/vim/vim.git /tmp/vim; \
+    cd /tmp/vim; \
+    ./configure \
+      --prefix=/opt/editor \
+      --with-features=huge \
+      --enable-multibyte \
+      --enable-terminal \
+      --without-x \
+      --disable-gui \
+      --enable-fail-if-missing; \
+    make -j"$(nproc)"; \
+    make install; \
+    ln -s /opt/editor/bin/vim /usr/local/bin/editor-under-test; \
+    rm -rf /tmp/vim; \
+  elif [ "$EDITOR_FLAVOR" = "nvim" ]; then \
+    mkdir -p /opt/editor /tmp/nvim-download; \
+    cd /tmp/nvim-download; \
+    base_url="https://github.com/neovim/neovim/releases/download/${EDITOR_VERSION}"; \
+    curl -fsSLO "${base_url}/nvim-linux-x86_64.tar.gz" \
+      || curl -fsSLO "${base_url}/nvim-linux64.tar.gz"; \
+    tar -xzf nvim-linux*.tar.gz --strip-components=1 -C /opt/editor; \
+    ln -s /opt/editor/bin/nvim /usr/local/bin/editor-under-test; \
+    rm -rf /tmp/nvim-download; \
+  else \
+    printf 'Unsupported EDITOR_FLAVOR: %s\n' "$EDITOR_FLAVOR" >&2; \
+    exit 1; \
+  fi
+
+WORKDIR /workspace
+
+CMD ["sh", "-lc", "node scripts/vim-version.js && yarn --version && yarn install --frozen-lockfile && yarn test:smoke"]

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,3 +1,10 @@
+let s:ROOT_DIR = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
+let s:plugin_path = s:ROOT_DIR . '/node_modules/@prettier/plugin-php/src/index.js'
+
 let b:prettier_ft_default_args = {
   \ 'parser': 'php',
   \ }
+
+if filereadable(s:plugin_path)
+  let b:prettier_ft_default_args['bundledPlugins'] = [s:plugin_path]
+endif

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,5 +1,5 @@
 let s:ROOT_DIR = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
-let s:plugin_path = s:ROOT_DIR . '/node_modules/@prettier/plugin-php/src/index.js'
+let s:plugin_path = s:ROOT_DIR . '/node_modules/@prettier/plugin-php/src/index.mjs'
 
 let b:prettier_ft_default_args = {
   \ 'parser': 'php',

--- a/ftplugin/svelte.vim
+++ b/ftplugin/svelte.vim
@@ -1,3 +1,10 @@
+let s:ROOT_DIR = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
+let s:plugin_path = s:ROOT_DIR . '/node_modules/prettier-plugin-svelte/plugin.js'
+
 let b:prettier_ft_default_args = {
   \ 'parser': 'svelte',
   \ }
+
+if filereadable(s:plugin_path)
+  let b:prettier_ft_default_args['bundledPlugins'] = [s:plugin_path]
+endif

--- a/ftplugin/xml.vim
+++ b/ftplugin/xml.vim
@@ -1,7 +1,14 @@
 " markdown/php files run this as well
 " https://stackoverflow.com/questions/22839269/why-does-vim-default-markdown-ftplugin-source-html-ftplugins-is-there-any-ways
 if expand('%:e') ==# 'xml'
+  let s:ROOT_DIR = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
+  let s:plugin_path = s:ROOT_DIR . '/node_modules/@prettier/plugin-xml/src/plugin.js'
+
   let b:prettier_ft_default_args = {
     \ 'parser': 'xml',
     \ }
+
+  if filereadable(s:plugin_path)
+    let b:prettier_ft_default_args['bundledPlugins'] = [s:plugin_path]
+  endif
 endif

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  snapshotFormat: {
+    escapeString: true,
+    printBasicPrototype: true,
+  },
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vim-prettier",
   "author": "Mitermayer Reis <mitermayer.reis@gmail.com>",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.1",
   "description": "Vim plugin for prettier",
   "license": "MIT",
   "repository": {
@@ -19,12 +19,11 @@
     "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."
   },
   "dependencies": {
-    "@prettier/plugin-lua": "0.0.1",
-    "@prettier/plugin-php": "^0.16.3",
-    "@prettier/plugin-ruby": "^0.8.0",
-    "@prettier/plugin-xml": "^0.7.2",
+    "@prettier/plugin-php": "^0.25.0",
+    "@prettier/plugin-xml": "^3.4.2",
     "prettier": "^3.0.3",
-    "prettier-plugin-svelte": "2.3.1"
+    "prettier-plugin-svelte": "^4.1.1",
+    "svelte": "^5.56.3"
   },
   "resolutions": {
     "**/brace-expansion": "1.1.15",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:formatting:core:exec": "node scripts/vim-version.js && node -e \"if (!process.env.PRETTIER_EXEC_CMD_PATH) { console.error('Set PRETTIER_EXEC_CMD_PATH to a Prettier executable'); process.exit(1); }\" && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand",
     "test:formatting:passing": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing node scripts/jest.js tests/formatting.test.js --runInBand",
     "test:formatting:quarantined": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined node scripts/jest.js tests/formatting.test.js --runInBand",
+    "test:editors:docker": "sh scripts/docker-editor-matrix.sh all",
     "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."
   },
   "dependencies": {
@@ -25,9 +26,13 @@
     "prettier": "^3.0.3",
     "prettier-plugin-svelte": "2.3.1"
   },
+  "resolutions": {
+    "**/brace-expansion": "1.1.15",
+    "**/js-yaml": "4.2.0",
+    "**/minimatch": "3.1.5"
+  },
   "devDependencies": {
     "colors": "^1.3.2",
-    "jest": "29.7.0",
-    "vim-driver": "^1.0.0"
+    "jest": "29.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "scripts": {
-    "test": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all node scripts/jest.js",
-    "test:smoke": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all node scripts/jest.js tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\"",
-    "test:formatting:core": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand",
-    "test:formatting:core:exec": "node scripts/vim-version.js && node -e \"if (!process.env.PRETTIER_EXEC_CMD_PATH) { console.error('Set PRETTIER_EXEC_CMD_PATH to a Prettier executable'); process.exit(1); }\" && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand",
-    "test:formatting:passing": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing node scripts/jest.js tests/formatting.test.js --runInBand",
-    "test:formatting:quarantined": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined node scripts/jest.js tests/formatting.test.js --runInBand",
+    "test": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all node scripts/jest.js --forceExit",
+    "test:smoke": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all node scripts/jest.js tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\" --forceExit",
+    "test:formatting:core": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand --forceExit",
+    "test:formatting:core:exec": "node scripts/vim-version.js && node -e \"if (!process.env.PRETTIER_EXEC_CMD_PATH) { console.error('Set PRETTIER_EXEC_CMD_PATH to a Prettier executable'); process.exit(1); }\" && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand --forceExit",
+    "test:formatting:passing": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing node scripts/jest.js tests/formatting.test.js --runInBand --forceExit",
+    "test:formatting:quarantined": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined node scripts/jest.js tests/formatting.test.js --runInBand --forceExit",
     "test:editors:docker": "sh scripts/docker-editor-matrix.sh all",
     "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config\"",
     "test:formatting:passing": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
     "test:formatting:quarantined": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
-    "lint": "vint --version && vint ."
+    "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."
   },
   "dependencies": {
     "@prettier/plugin-lua": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "scripts": {
-    "test": "node scripts/vim-version.js && LOG_LEVEL=error jest",
-    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config version detection works inside vim-driver execute\"",
+    "test": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest",
+    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config version detection works inside vim-driver execute\"",
+    "test:formatting:passing": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
+    "test:formatting:quarantined": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
     "lint": "vint --version && vint ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest",
-    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config\"",
+    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\"",
     "test:formatting:passing": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
     "test:formatting:quarantined": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
     "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "scripts": {
-    "test": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest",
-    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\"",
-    "test:formatting:passing": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
-    "test:formatting:quarantined": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
+    "test": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest",
+    "test:smoke": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\"",
+    "test:formatting:core": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core jest tests/formatting.test.js --runInBand",
+    "test:formatting:core:exec": "node scripts/vim-version.js && node -e \"if (!process.env.PRETTIER_EXEC_CMD_PATH) { console.error('Set PRETTIER_EXEC_CMD_PATH to a Prettier executable'); process.exit(1); }\" && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core jest tests/formatting.test.js --runInBand",
+    "test:formatting:passing": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
+    "test:formatting:quarantined": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
     "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "scripts": {
-    "test": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest",
-    "test:smoke": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\"",
-    "test:formatting:core": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core jest tests/formatting.test.js --runInBand",
-    "test:formatting:core:exec": "node scripts/vim-version.js && node -e \"if (!process.env.PRETTIER_EXEC_CMD_PATH) { console.error('Set PRETTIER_EXEC_CMD_PATH to a Prettier executable'); process.exit(1); }\" && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core jest tests/formatting.test.js --runInBand",
-    "test:formatting:passing": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
-    "test:formatting:quarantined": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
+    "test": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all node scripts/jest.js",
+    "test:smoke": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all node scripts/jest.js tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config|Prettier command shell\"",
+    "test:formatting:core": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand",
+    "test:formatting:core:exec": "node scripts/vim-version.js && node -e \"if (!process.env.PRETTIER_EXEC_CMD_PATH) { console.error('Set PRETTIER_EXEC_CMD_PATH to a Prettier executable'); process.exit(1); }\" && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=core node scripts/jest.js tests/formatting.test.js --runInBand",
+    "test:formatting:passing": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing node scripts/jest.js tests/formatting.test.js --runInBand",
+    "test:formatting:quarantined": "node scripts/vim-version.js && PRETTIER_EXEC_CMD_PATH= LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined node scripts/jest.js tests/formatting.test.js --runInBand",
     "lint": "sh scripts/vint.sh --version && sh scripts/vint.sh ."
   },
   "dependencies": {
@@ -23,11 +23,11 @@
     "@prettier/plugin-ruby": "^0.8.0",
     "@prettier/plugin-xml": "^0.7.2",
     "prettier": "^3.0.3",
-    "prettier-plugin-svelte": "^2.3.1"
+    "prettier-plugin-svelte": "2.3.1"
   },
   "devDependencies": {
     "colors": "^1.3.2",
-    "jest": "^23.6.0",
+    "jest": "29.7.0",
     "vim-driver": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest",
-    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config version detection works inside vim-driver execute\"",
+    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=all jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config\"",
     "test:formatting:passing": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=known-passing jest tests/formatting.test.js --runInBand",
     "test:formatting:quarantined": "node scripts/vim-version.js && LOG_LEVEL=error PRETTIER_FORMATTING_FIXTURE_LANE=quarantined jest tests/formatting.test.js --runInBand",
     "lint": "vint --version && vint ."

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "git://github.com/prettier/vim-prettier.git"
   },
   "scripts": {
-    "test": "vim --version && LOG_LEVEL=error jest",
+    "test": "node scripts/vim-version.js && LOG_LEVEL=error jest",
+    "test:smoke": "node scripts/vim-version.js && LOG_LEVEL=error jest tests/formatting.test.js --runInBand --testNamePattern=\"Prettier config version detection works inside vim-driver execute\"",
     "lint": "vint --version && vint ."
   },
   "dependencies": {

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -79,6 +79,9 @@ let g:prettier#config#use_tabs = get(g:,'prettier#config#use_tabs', 'auto')
 " See more: https://prettier.io/docs/en/options.html#parser
 let g:prettier#config#parser = get(g:,'prettier#config#parser', '')
 
+" Prettier plugin paths to load. Accepts a string or list of strings.
+let g:prettier#config#plugins = get(g:, 'prettier#config#plugins', [])
+
 " cli-override|file-override|prefer-file
 " default: 'file-override'
 " See more: https://prettier.io/docs/en/cli.html#--config-precedence

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -26,15 +26,27 @@ let g:prettier#autoformat_require_pragma = get(g:, 'prettier#autoformat_require_
 " whether to turn autoformatting on if a prettier config file is found
 let g:prettier#autoformat_config_present = get(g:, 'prettier#autoformat_config_present', 0)
 
-" prettier config files to search current directory and parent directories for
+" prettier config files to search buffer directory and parent directories for
 let g:prettier#autoformat_config_files = get(g:, 'prettier#autoformat_config_files', [
       \'.prettierrc',
-      \'.prettierrc.yml',
-      \'.prettierrc.yaml',
-      \'.prettierrc.js',
-      \'.prettierrc.config.js',
       \'.prettierrc.json',
-      \'.prettierrc.toml'])
+      \'.prettierrc.yaml',
+      \'.prettierrc.yml',
+      \'.prettierrc.json5',
+      \'.prettierrc.js',
+      \'.prettierrc.mjs',
+      \'.prettierrc.cjs',
+      \'.prettierrc.ts',
+      \'.prettierrc.mts',
+      \'.prettierrc.cts',
+      \'prettier.config.js',
+      \'prettier.config.mjs',
+      \'prettier.config.cjs',
+      \'prettier.config.ts',
+      \'prettier.config.mts',
+      \'prettier.config.cts',
+      \'.prettierrc.toml',
+      \'.prettierrc.config.js'])
 
 " path to prettier cli
 let g:prettier#exec_cmd_path = get(g:, 'prettier#exec_cmd_path', 0)

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -5,7 +5,7 @@
 " Name Of File: prettier.vim
 "  Description: A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
 "   Maintainer: Mitermayer Reis <mitermayer.reis at gmail.com>
-"      Version: 1.0.0
+"      Version: 2.0.0-beta.1
 "        Usage: Use :help vim-prettier-usage, or visit https://github.com/prettier/vim-prettier
 "
 "==========================================================================================================
@@ -159,7 +159,7 @@ command! -nargs=? -range=% Prettier call prettier#Prettier(g:prettier#exec_cmd_a
 command! -nargs=? -range=% PrettierAsync call prettier#Prettier(1, <line1>, <line2>, g:prettier#partial_format)
 
 " prints vim-prettier version
-command! -nargs=? -range=% PrettierVersion echom '1.0.0'
+command! -nargs=? -range=% PrettierVersion echom '2.0.0-beta.1'
 
 " call prettier cli
 command! -nargs=? -range=% PrettierCli call prettier#PrettierCli(<q-args>)

--- a/requirements-vint.txt
+++ b/requirements-vint.txt
@@ -1,0 +1,5 @@
+ansicolor==0.3.3
+chardet==5.2.0
+PyYAML==6.0.3
+setuptools==68.2.2
+vim-vint==0.3.21

--- a/scripts/docker-editor-matrix.sh
+++ b/scripts/docker-editor-matrix.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+DOCKERFILE="$ROOT_DIR/docker/editor-matrix.Dockerfile"
+PLATFORM=${DOCKER_PLATFORM:-linux/amd64}
+VIM_STABLE_VERSION=${VIM_STABLE_VERSION:-v9.1.2050}
+COMMAND=${DOCKER_MATRIX_COMMAND:-"node scripts/vim-version.js && yarn --version && yarn install --frozen-lockfile && yarn test:smoke"}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/docker-editor-matrix.sh [target|all]
+
+Targets:
+  vim-8.2       Vim v8.2.5172
+  vim-stable    Vim stable tag from VIM_STABLE_VERSION, default v9.1.2050
+  nvim-0.9      Neovim v0.9.5
+  nvim-stable   Neovim stable release
+  all           Run every target
+
+Environment:
+  DOCKER_PLATFORM        Docker platform, default linux/amd64
+  VIM_STABLE_VERSION     Vim tag for vim-stable, default v9.1.2050
+  DOCKER_MATRIX_COMMAND  Command to run in /workspace inside the container
+
+Examples:
+  scripts/docker-editor-matrix.sh vim-8.2
+  scripts/docker-editor-matrix.sh all
+  DOCKER_MATRIX_COMMAND='yarn test:formatting:core' scripts/docker-editor-matrix.sh vim-stable
+USAGE
+}
+
+target_flavor() {
+  case "$1" in
+    vim-8.2|vim-stable) printf '%s\n' vim ;;
+    nvim-0.9|nvim-stable) printf '%s\n' nvim ;;
+    *) return 1 ;;
+  esac
+}
+
+target_version() {
+  case "$1" in
+    vim-8.2) printf '%s\n' v8.2.5172 ;;
+    vim-stable) printf '%s\n' "$VIM_STABLE_VERSION" ;;
+    nvim-0.9) printf '%s\n' v0.9.5 ;;
+    nvim-stable) printf '%s\n' stable ;;
+    *) return 1 ;;
+  esac
+}
+
+run_target() {
+  target=$1
+  flavor=$(target_flavor "$target")
+  version=$(target_version "$target")
+  image="vim-prettier-editor-matrix:${target}"
+  node_modules_volume="vim-prettier-editor-matrix-${target}-node-modules"
+  yarn_cache_volume="vim-prettier-editor-matrix-yarn-cache"
+  editor_executable=/usr/local/bin/editor-under-test
+  editor_executable_args=
+
+  if [ "$flavor" = nvim ]; then
+    editor_executable_args=--headless
+  fi
+
+  printf 'Building %s (%s %s) for %s\n' "$target" "$flavor" "$version" "$PLATFORM"
+  docker build \
+    --platform "$PLATFORM" \
+    --build-arg "EDITOR_FLAVOR=$flavor" \
+    --build-arg "EDITOR_VERSION=$version" \
+    -f "$DOCKERFILE" \
+    -t "$image" \
+    "$ROOT_DIR/docker"
+
+  printf 'Running %s\n' "$target"
+  docker run \
+    --rm \
+    --platform "$PLATFORM" \
+    -e "VIM_EXECUTABLE=$editor_executable" \
+    -e "VIM_EXECUTABLE_ARGS=$editor_executable_args" \
+    -e PRETTIER_EXEC_CMD_PATH= \
+    -e LOG_LEVEL=error \
+    -e PRETTIER_FORMATTING_FIXTURE_LANE=all \
+    -v "$ROOT_DIR:/workspace" \
+    -v "$node_modules_volume:/workspace/node_modules" \
+    -v "$yarn_cache_volume:/usr/local/share/.cache/yarn" \
+    -w /workspace \
+    "$image" \
+    sh -lc "$COMMAND"
+}
+
+target=${1:-all}
+
+case "$target" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  all)
+    for matrix_target in vim-8.2 vim-stable nvim-0.9 nvim-stable; do
+      run_target "$matrix_target"
+    done
+    ;;
+  vim-8.2|vim-stable|nvim-0.9|nvim-stable)
+    run_target "$target"
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/jest.js
+++ b/scripts/jest.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+// Node 25 exposes experimental webstorage globals whose lazy getters throw
+// unless Node is started with a storage path. Jest 29 copies globals when the
+// node environment starts, so remove them before Jest loads.
+delete globalThis.localStorage;
+delete globalThis.sessionStorage;
+
+require('jest/bin/jest');

--- a/scripts/vim-version.js
+++ b/scripts/vim-version.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require('child_process');
+const path = require('path');
 
 const vimExecutable = process.env.VIM_EXECUTABLE || 'vim';
-const result = spawnSync(vimExecutable, ['--version'], { stdio: 'inherit' });
+const result = spawnSync(vimExecutable, ['--version'], { encoding: 'utf8' });
 
 if (result.error) {
   console.error(
@@ -12,9 +13,50 @@ if (result.error) {
   process.exit(1);
 }
 
+const stdout = result.stdout || '';
+const stderr = result.stderr || '';
+
+process.stdout.write(stdout);
+process.stderr.write(stderr);
+
 if (result.signal) {
   console.error(`${vimExecutable} --version exited with signal ${result.signal}`);
   process.exit(1);
 }
 
-process.exit(typeof result.status === 'number' ? result.status : 1);
+if (result.status !== 0) {
+  process.exit(typeof result.status === 'number' ? result.status : 1);
+}
+
+const output = `${stdout}\n${stderr}`;
+const requiredFeatures = ['+job', '+channel'];
+const executableName = path.basename(vimExecutable).toLowerCase();
+const isNeovim =
+  executableName === 'nvim' ||
+  executableName === 'nvim.exe' ||
+  /\bNVIM\b/.test(output);
+
+if (isNeovim) {
+  console.log('Detected Neovim; Vim +job/+channel feature checks are not applicable.');
+  process.exit(0);
+}
+
+const missingFeatures = requiredFeatures.filter(
+  (feature) => !output.includes(feature)
+);
+
+if (missingFeatures.length > 0) {
+  const versionLine =
+    output.split(/\r?\n/).find(Boolean) || `${vimExecutable} --version`;
+
+  console.error(
+    `${vimExecutable} is missing required Vim feature(s): ${missingFeatures.join(', ')}`
+  );
+  console.error(`Version reported: ${versionLine}`);
+  console.error('Blocking CI jobs require Vim with +job and +channel.');
+  process.exit(1);
+}
+
+console.log(
+  `Verified required Vim features for ${vimExecutable}: ${requiredFeatures.join(' ')}`
+);

--- a/scripts/vim-version.js
+++ b/scripts/vim-version.js
@@ -4,7 +4,10 @@ const { spawnSync } = require('child_process');
 const path = require('path');
 
 const vimExecutable = process.env.VIM_EXECUTABLE || 'vim';
-const result = spawnSync(vimExecutable, ['--version'], { encoding: 'utf8' });
+const vimExecutableArgs = (process.env.VIM_EXECUTABLE_ARGS || '')
+  .split(/\s+/)
+  .filter(Boolean);
+const result = spawnSync(vimExecutable, [...vimExecutableArgs, '--version'], { encoding: 'utf8' });
 
 if (result.error) {
   console.error(

--- a/scripts/vim-version.js
+++ b/scripts/vim-version.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+
+const vimExecutable = process.env.VIM_EXECUTABLE || 'vim';
+const result = spawnSync(vimExecutable, ['--version'], { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(
+    `Failed to run ${vimExecutable} --version: ${result.error.message}`
+  );
+  process.exit(1);
+}
+
+if (result.signal) {
+  console.error(`${vimExecutable} --version exited with signal ${result.signal}`);
+  process.exit(1);
+}
+
+process.exit(typeof result.status === 'number' ? result.status : 1);

--- a/scripts/vint.sh
+++ b/scripts/vint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
+REQUIREMENTS_FILE="$ROOT_DIR/requirements-vint.txt"
+VENV_DIR=${VINT_VENV_DIR:-$ROOT_DIR/.venv-vint}
+PYTHON_BIN=${VINT_PYTHON:-python3}
+STAMP_FILE="$VENV_DIR/.requirements-vint.txt"
+
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+if [ ! -x "$VENV_DIR/bin/vint" ] || [ ! -f "$STAMP_FILE" ] || ! cmp -s "$REQUIREMENTS_FILE" "$STAMP_FILE"; then
+  "$VENV_DIR/bin/python" -m pip install --disable-pip-version-check -r "$REQUIREMENTS_FILE"
+  cp "$REQUIREMENTS_FILE" "$STAMP_FILE"
+fi
+
+exec "$VENV_DIR/bin/vint" "$@"

--- a/tests/__snapshots__/formatting.test.js.snap
+++ b/tests/__snapshots__/formatting.test.js.snap
@@ -20,35 +20,35 @@ exports[`Prettier formats foo.css file with :PrettierAsync command 1`] = `
 
 exports[`Prettier formats foo.graphql file with :Prettier command 1`] = `
 "{
-  baz {
-    blah
-    ...name
-  }
-  bean {
-    foo
-    blah
-    bleh
-  }
-  bar {
-    ...name
-  }
+    baz {
+        blah
+        ...name
+    }
+    bean {
+        foo
+        blah
+        bleh
+    }
+    bar {
+        ...name
+    }
 }"
 `;
 
 exports[`Prettier formats foo.graphql file with :PrettierAsync command 1`] = `
 "{
-  baz {
-    blah
-    ...name
-  }
-  bean {
-    foo
-    blah
-    bleh
-  }
-  bar {
-    ...name
-  }
+    baz {
+        blah
+        ...name
+    }
+    bean {
+        foo
+        blah
+        bleh
+    }
+    bar {
+        ...name
+    }
 }"
 `;
 

--- a/tests/__snapshots__/formatting.test.js.snap
+++ b/tests/__snapshots__/formatting.test.js.snap
@@ -200,6 +200,22 @@ exports[`Prettier formats foo.scss file with :PrettierAsync command 1`] = `
 }"
 `;
 
+exports[`Prettier formats foo.svelte file with :Prettier command 1`] = `
+"<script>
+    let name = \\"world\\";
+</script>
+
+<h1>Hello {name}</h1>"
+`;
+
+exports[`Prettier formats foo.svelte file with :PrettierAsync command 1`] = `
+"<script>
+    let name = \\"world\\";
+</script>
+
+<h1>Hello {name}</h1>"
+`;
+
 exports[`Prettier formats foo.ts file with :Prettier command 1`] = `
 "const a: () => number = () => {
     return 2;

--- a/tests/__snapshots__/formatting.test.js.snap
+++ b/tests/__snapshots__/formatting.test.js.snap
@@ -20,35 +20,35 @@ exports[`Prettier formats foo.css file with :PrettierAsync command 1`] = `
 
 exports[`Prettier formats foo.graphql file with :Prettier command 1`] = `
 "{
-    baz {
-        blah
-        ...name
-    }
-    bean {
-        foo
-        blah
-        bleh
-    }
-    bar {
-        ...name
-    }
+  baz {
+    blah
+    ...name
+  }
+  bean {
+    foo
+    blah
+    bleh
+  }
+  bar {
+    ...name
+  }
 }"
 `;
 
 exports[`Prettier formats foo.graphql file with :PrettierAsync command 1`] = `
 "{
-    baz {
-        blah
-        ...name
-    }
-    bean {
-        foo
-        blah
-        bleh
-    }
-    bar {
-        ...name
-    }
+  baz {
+    blah
+    ...name
+  }
+  bean {
+    foo
+    blah
+    bleh
+  }
+  bar {
+    ...name
+  }
 }"
 `;
 
@@ -162,16 +162,16 @@ Lorem ipsum dolor amet
 
 exports[`Prettier formats foo.php file with :Prettier command 1`] = `
 "<?php
-$a = 'a';
+$a = \\"a\\";
 
-$b = $a . $a . ' asda';"
+$b = $a . $a . \\" asda\\";"
 `;
 
 exports[`Prettier formats foo.php file with :PrettierAsync command 1`] = `
 "<?php
-$a = 'a';
+$a = \\"a\\";
 
-$b = $a . $a . ' asda';"
+$b = $a . $a . \\" asda\\";"
 `;
 
 exports[`Prettier formats foo.rb file with :Prettier command 1`] = `
@@ -188,19 +188,19 @@ end"
 
 exports[`Prettier formats foo.scss file with :Prettier command 1`] = `
 ".redClass {
-    background: \\"red\\";
+  background: \\"red\\";
 }
 #redId {
-    background: \\"red\\";
+  background: \\"red\\";
 }"
 `;
 
 exports[`Prettier formats foo.scss file with :PrettierAsync command 1`] = `
 ".redClass {
-    background: \\"red\\";
+  background: \\"red\\";
 }
 #redId {
-    background: \\"red\\";
+  background: \\"red\\";
 }"
 `;
 
@@ -225,7 +225,7 @@ exports[`Prettier formats foo.vue file with :Prettier command 1`] = `
 export default {
     data() {
         return { msg: \\"Hello world!\\" };
-    }
+    },
 };
 </script>
 
@@ -249,7 +249,7 @@ exports[`Prettier formats foo.vue file with :PrettierAsync command 1`] = `
 export default {
     data() {
         return { msg: \\"Hello world!\\" };
-    }
+    },
 };
 </script>
 
@@ -310,20 +310,20 @@ exports[`Prettier formats foo.xml file with :PrettierAsync command 1`] = `
 
 exports[`Prettier formats foo.yaml file with :Prettier command 1`] = `
 "foo:
-    bar:
-        baz:
-            bleh: ./foo
-            foobar: foobar
-            args:
-                buildno: 1"
+  bar:
+    baz:
+      bleh: ./foo
+      foobar: foobar
+      args:
+        buildno: 1"
 `;
 
 exports[`Prettier formats foo.yaml file with :PrettierAsync command 1`] = `
 "foo:
-    bar:
-        baz:
-            bleh: ./foo
-            foobar: foobar
-            args:
-                buildno: 1"
+  bar:
+    baz:
+      bleh: ./foo
+      foobar: foobar
+      args:
+        buildno: 1"
 `;

--- a/tests/__snapshots__/formatting.test.js.snap
+++ b/tests/__snapshots__/formatting.test.js.snap
@@ -143,9 +143,7 @@ Lorem ipsum dolor amet
 
 ### bar
 
--   a
--   b
--   c"
+A short paragraph."
 `;
 
 exports[`Prettier formats foo.md file with :PrettierAsync command 1`] = `
@@ -155,9 +153,7 @@ Lorem ipsum dolor amet
 
 ### bar
 
--   a
--   b
--   c"
+A short paragraph."
 `;
 
 exports[`Prettier formats foo.php file with :Prettier command 1`] = `

--- a/tests/fixtures/foo.md
+++ b/tests/fixtures/foo.md
@@ -6,6 +6,4 @@ Lorem ipsum dolor amet
 
 
 
-- a 
-- b 
-- c
+A short paragraph.

--- a/tests/fixtures/foo.svelte
+++ b/tests/fixtures/foo.svelte
@@ -1,0 +1,1 @@
+<script>let name="world"</script><h1>Hello {name}</h1>

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -5,7 +5,7 @@ const HeadlessRemoteClient = require('vim-driver/dist/HeadlessRemoteClient');
 const Server = require('vim-driver/dist/Server');
 
 const HOST = '127.0.0.1';
-const PORT = 1337;
+const PORT = Number(process.env.VIM_DRIVER_PORT || 10000 + (process.pid % 50000));
 const FIXTURES_DIR = `${__dirname}/fixtures`;
 const VIMRC = `${__dirname}/vimrc`;
 const FORMAT_FIXTURE_LANE = process.env.PRETTIER_FORMATTING_FIXTURE_LANE || 'all';
@@ -121,10 +121,30 @@ const writeFakePrettierExecutable = (prettierPath, options = {}) => {
   }
 
   if (Object.prototype.hasOwnProperty.call(options, 'formattedOutput')) {
+    if (options.delaySeconds) {
+      script.push(`sleep ${options.delaySeconds}`);
+    }
+
     script.push(
       'cat >/dev/null',
       `printf '%s\\n' ${shellQuote(options.formattedOutput)}`
     );
+  } else if (options.stderr) {
+    if (options.delaySeconds) {
+      script.push(`sleep ${options.delaySeconds}`);
+    }
+
+    script.push(
+      'cat >/dev/null',
+      `printf '%s\\n' ${shellQuote(options.stderr)} >&2`,
+      `exit ${options.exitCode || 1}`
+    );
+  } else {
+    if (options.delaySeconds) {
+      script.push(`sleep ${options.delaySeconds}`);
+    }
+
+    script.push('cat >/dev/null');
   }
 
   script.push('exit 0');
@@ -171,6 +191,27 @@ const createShellSafetyPrettierFixture = () => {
   fs.writeFileSync(sourcePath, 'const formatted=false\n');
 
   return { root, prettierPath, sourcePath };
+};
+
+const createAsyncPrettierFixture = (files, options = {}) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vim-prettier-async-'));
+  const binDir = path.join(root, 'node_modules', '.bin');
+  const sourceDir = path.join(root, 'src');
+  const prettierPath = path.join(binDir, 'prettier');
+  const sourcePaths = {};
+
+  tempProjectRoots.push(root);
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(sourceDir, { recursive: true });
+  writeFakePrettierExecutable(prettierPath, options);
+
+  Object.keys(files).forEach(file => {
+    const sourcePath = path.join(sourceDir, file);
+    fs.writeFileSync(sourcePath, files[file]);
+    sourcePaths[file] = sourcePath;
+  });
+
+  return { root, prettierPath, sourcePaths };
 };
 
 const createConfigDiscoveryFixture = configFileName => {
@@ -497,8 +538,32 @@ if (FORMAT_FIXTURE_LANE === 'all') {
       }
     });
 
-    test('does not inject bundled PHP plugin for project-local Prettier', async () => {
-      const project = createProjectLocalPrettierFixture('php');
+    test.each([
+      ['PHP', 'foo.php'],
+      ['XML', 'foo.xml'],
+    ])('injects bundled %s plugin for bundled Prettier', async (_name, fixture) => {
+      await setVimCwd(__dirname);
+      await remote.edit(`${FIXTURES_DIR}/${fixture}`);
+
+      const resolvedPath = await remote.eval(
+        'prettier#resolver#executable#getPath()'
+      );
+      const bundledPluginPath = await remote.eval(
+        "get(b:prettier_ft_default_args, 'bundledPlugins', [''])[0]"
+      );
+      const flags = await resolveConfigFlags('b:prettier_ft_default_args');
+
+      expect(resolvedPath).toContain(path.join('vim-prettier', 'node_modules'));
+      expect(bundledPluginPath).toContain(path.join('vim-prettier', 'node_modules'));
+      expect(flags).toContain(`--plugin='${bundledPluginPath}'`);
+      expect(countPluginFlags(flags)).toBe(1);
+    });
+
+    test.each([
+      ['PHP', 'php'],
+      ['XML', 'xml'],
+    ])('does not inject bundled %s plugin for project-local Prettier', async (_name, extension) => {
+      const project = createProjectLocalPrettierFixture(extension);
 
       await setVimCwd(__dirname);
       await remote.edit(project.sourcePath);
@@ -563,6 +628,43 @@ if (FORMAT_FIXTURE_LANE === 'all') {
       expect(flags).not.toContain(`--stdin-filepath="${project.sourcePath}"`);
     });
 
+    test('builds argv args without shellescaping paths containing spaces and quotes', async () => {
+      const project = createShellSafetyPrettierFixture();
+      const pluginPath = path.join(project.root, 'plugin path', 'prettier-plugin-example.js');
+
+      await editFile(project.sourcePath);
+
+      const args = await remote.eval(
+        `prettier#resolver#config#resolve_args({'plugins': ${vimString(pluginPath)}}, 0, 1, 1)`
+      );
+
+      expect(args).toContain(`--stdin-filepath=${project.sourcePath}`);
+      expect(args).toContain(`--plugin=${pluginPath}`);
+      expect(args).not.toContain(`--stdin-filepath='${project.sourcePath}'`);
+      expect(args).not.toContain(`--plugin='${pluginPath}'`);
+    });
+
+    test('builds command argv while preserving shell-string fallback', async () => {
+      const project = createShellSafetyPrettierFixture();
+
+      await editFile(project.sourcePath);
+
+      const command = await remote.eval(
+        `prettier#command#build(${vimString(project.prettierPath)}, {}, 0, 1, 1)`
+      );
+      const shellExecutable = await remote.eval(
+        `shellescape(${vimString(project.prettierPath)})`
+      );
+      const shellFilepath = await remote.eval(
+        "shellescape(simplify(expand('%:p')))"
+      );
+
+      expect(command.argv[0]).toBe(project.prettierPath);
+      expect(command.argv).toContain(`--stdin-filepath=${project.sourcePath}`);
+      expect(command.shell).toContain(shellExecutable);
+      expect(command.shell).toContain(`--stdin-filepath=${shellFilepath}`);
+    });
+
     test(':Prettier runs a project-local executable from a shell-escaped path', async () => {
       const project = createShellSafetyPrettierFixture();
 
@@ -578,6 +680,107 @@ if (FORMAT_FIXTURE_LANE === 'all') {
       await remote.execute('Prettier');
 
       expect(await getBufferContents(remote)).toBe('const formatted = true;');
+    });
+  });
+
+  describe('Prettier async safety', () => {
+    test(':PrettierAsync updates the buffer without writing to disk', async () => {
+      const project = createAsyncPrettierFixture(
+        { 'manual.js': 'const formatted=false\n' },
+        { formattedOutput: 'const formatted = true;' }
+      );
+      const sourcePath = project.sourcePaths['manual.js'];
+
+      await editFile(sourcePath);
+      await remote.execute('PrettierAsync');
+      await waitUntil(async () => (await getBufferContents(remote)) === 'const formatted = true;');
+
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
+      expect(fs.readFileSync(sourcePath, 'utf8')).toBe('const formatted=false\n');
+    });
+
+    test('runs async jobs independently per buffer', async () => {
+      const project = createAsyncPrettierFixture(
+        {
+          'one.js': 'const one=false\n',
+          'two.js': 'const two=false\n',
+        },
+        { delaySeconds: 1, formattedOutput: 'const formatted = true;' }
+      );
+
+      await remote.execute('set hidden');
+      await editFile(project.sourcePaths['one.js']);
+      const firstBuffer = await remote.eval('bufnr("%")');
+      await remote.execute('PrettierAsync');
+      await editFile(project.sourcePaths['two.js']);
+      await remote.execute('PrettierAsync');
+
+      await waitUntil(async () => (await getBufferContents(remote)) === 'const formatted = true;', 3000);
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
+
+      await remote.execute(`execute 'buffer' ${firstBuffer}`);
+      await waitUntil(async () => (await getBufferContents(remote)) === 'const formatted = true;', 3000);
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
+    });
+
+    test('does not replace a buffer changed after async formatting starts', async () => {
+      const project = createAsyncPrettierFixture(
+        { 'stale.js': 'const stale=false\n' },
+        { delaySeconds: 1, formattedOutput: 'const formatted = true;' }
+      );
+
+      await editFile(project.sourcePaths['stale.js']);
+      await remote.execute('PrettierAsync');
+      await remote.execute("call setline(1, 'const userEdit = true;')");
+      await sleep(1500);
+
+      expect(await getBufferContents(remote)).toBe('const userEdit = true;');
+
+      await remote.execute('PrettierAsync');
+      await waitUntil(async () => (await getBufferContents(remote)) === 'const formatted = true;', 3000);
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
+    });
+
+    test('resets async job state after ignored empty output', async () => {
+      const project = createAsyncPrettierFixture(
+        { 'ignored.js': 'const ignored=false\n' },
+        { delaySeconds: 1 }
+      );
+      const sourcePath = project.sourcePaths['ignored.js'];
+
+      await editFile(sourcePath);
+      await remote.execute('PrettierAsync');
+      await sleep(1500);
+      writeFakePrettierExecutable(project.prettierPath, {
+        formattedOutput: 'const formatted = true;',
+      });
+      await remote.execute('PrettierAsync');
+      await waitUntil(async () => (await getBufferContents(remote)) === 'const formatted = true;');
+
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
+    });
+
+    test('opens quickfix and resets async job state after parser errors', async () => {
+      const project = createAsyncPrettierFixture(
+        { 'broken.js': 'const broken =\n' },
+        { stderr: 'stdin: SyntaxError: Unexpected token (1:15)' }
+      );
+
+      await editFile(project.sourcePaths['broken.js']);
+      await remote.execute('let g:prettier#quickfix_auto_focus = 0');
+      await remote.execute('PrettierAsync');
+      await waitUntil(async () => Number(await remote.eval('len(getqflist())')) > 0);
+
+      expect(await remote.eval('getqflist()[0].text')).toBe('Unexpected token');
+
+      writeFakePrettierExecutable(project.prettierPath, {
+        formattedOutput: 'const formatted = true;',
+      });
+      await remote.execute('PrettierAsync');
+      await waitUntil(async () => (await getBufferContents(remote)) === 'const formatted = true;');
+
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
+      await remote.execute('let g:prettier#quickfix_auto_focus = 1');
     });
   });
 }

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -48,6 +48,12 @@ const getBufferContents = async remote =>
 
 const vimString = value => `'${value.replace(/'/g, "''")}'`;
 
+const vimStringExpr = value =>
+  value
+    .split('"')
+    .map(vimString)
+    .join(' . nr2char(34) . ');
+
 const removeDirectorySync = dir => {
   if (!fs.existsSync(dir)) {
     return;
@@ -72,17 +78,41 @@ const cleanupTempProjects = () => {
   }
 };
 
-const writeFakePrettierExecutable = prettierPath => {
-  fs.writeFileSync(
-    prettierPath,
-    [
-      '#!/bin/sh',
-      'if [ "$1" = "--version" ]; then',
-      "  printf '3.0.3\\n'",
-      'fi',
-      'exit 0',
-    ].join('\n') + '\n'
-  );
+const writeFakePrettierExecutable = (prettierPath, options = {}) => {
+  const script = [
+    '#!/bin/sh',
+    'if [ "$1" = "--version" ]; then',
+    "  printf '3.0.3\\n'",
+    '  exit 0',
+    'fi',
+  ];
+
+  if (options.expectedStdinFilepath) {
+    script.push(
+      `expected_stdin_filepath=${shellQuote(options.expectedStdinFilepath)}`,
+      'found_stdin_filepath=0',
+      'for arg in "$@"; do',
+      '  if [ "$arg" = "--stdin-filepath=$expected_stdin_filepath" ]; then',
+      '    found_stdin_filepath=1',
+      '  fi',
+      'done',
+      'if [ "$found_stdin_filepath" != "1" ]; then',
+      "  printf '%s\\n' 'missing expected stdin filepath' >&2",
+      '  exit 2',
+      'fi'
+    );
+  }
+
+  if (Object.prototype.hasOwnProperty.call(options, 'formattedOutput')) {
+    script.push(
+      'cat >/dev/null',
+      `printf '%s\\n' ${shellQuote(options.formattedOutput)}`
+    );
+  }
+
+  script.push('exit 0');
+
+  fs.writeFileSync(prettierPath, script.join('\n') + '\n');
   fs.chmodSync(prettierPath, 0o755);
 };
 
@@ -105,8 +135,32 @@ const createProjectLocalPrettierFixture = extension => {
   return { root, prettierPath, sourcePath };
 };
 
+const createShellSafetyPrettierFixture = () => {
+  const root = fs.mkdtempSync(
+    path.join(fs.realpathSync(os.tmpdir()), 'vim-prettier shell "quote" ')
+  );
+  const binDir = path.join(root, 'node_modules', '.bin');
+  const sourceDir = path.join(root, 'src with spaces');
+  const prettierPath = path.join(binDir, 'prettier');
+  const sourcePath = path.join(sourceDir, 'index "quote".js');
+
+  tempProjectRoots.push(root);
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(sourceDir, { recursive: true });
+  writeFakePrettierExecutable(prettierPath, {
+    expectedStdinFilepath: sourcePath,
+    formattedOutput: 'const formatted = true;',
+  });
+  fs.writeFileSync(sourcePath, 'const formatted=false\n');
+
+  return { root, prettierPath, sourcePath };
+};
+
 const setVimCwd = dir =>
-  remote.execute(`execute 'cd' fnameescape(${vimString(dir)})`);
+  remote.execute(`execute 'cd' fnameescape(${vimStringExpr(dir)})`);
+
+const editFile = file =>
+  remote.execute(`execute 'edit' fnameescape(${vimStringExpr(file)})`);
 
 const resolveConfigFlags = config =>
   remote.eval(`prettier#resolver#config#resolve(${config}, 0, 1, 1)`);
@@ -428,6 +482,39 @@ if (FORMAT_FIXTURE_LANE === 'all') {
       expect(hasBundledPlugins).toBe(1);
       expect(flags).not.toContain(bundledPluginPath);
       expectNoPluginFlags(flags);
+    });
+  });
+
+  describe('Prettier command shell safety', () => {
+    test('shellescapes stdin filepath for paths containing spaces and quotes', async () => {
+      const project = createShellSafetyPrettierFixture();
+
+      await editFile(project.sourcePath);
+
+      const flags = await resolveConfigFlags('{}');
+      const expectedPath = await remote.eval(
+        "shellescape(simplify(expand('%:p')))"
+      );
+
+      expect(flags).toContain(`--stdin-filepath=${expectedPath}`);
+      expect(flags).not.toContain(`--stdin-filepath="${project.sourcePath}"`);
+    });
+
+    test(':Prettier runs a project-local executable from a shell-escaped path', async () => {
+      const project = createShellSafetyPrettierFixture();
+
+      await setVimCwd(__dirname);
+      await editFile(project.sourcePath);
+
+      const resolvedPath = await remote.eval(
+        'prettier#resolver#executable#getPath()'
+      );
+
+      expect(resolvedPath).toBe(project.prettierPath);
+
+      await remote.execute('Prettier');
+
+      expect(await getBufferContents(remote)).toBe('const formatted = true;');
     });
   });
 }

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -44,6 +44,17 @@ jest.setTimeout(15000);
 const getBufferContents = async remote =>
   (await remote.call('getline', [1, '$'])).join('\n');
 
+const vimString = value => `'${value.replace(/'/g, "''")}'`;
+
+const resolveConfigFlags = config =>
+  remote.eval(`prettier#resolver#config#resolve(${config}, 0, 1, 1)`);
+
+const expectNoPluginFlags = flags => {
+  expect(flags).not.toContain('--plugin=');
+};
+
+const countPluginFlags = flags => (flags.match(/--plugin=/g) || []).length;
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 const waitUntil = (condition, timeout = 2000) => {
   return new Promise(resolve => {
@@ -163,6 +174,87 @@ if (FORMAT_FIXTURE_LANE === 'all') {
     await expect(
       remote.execute('call prettier#resolver#config#resolve({}, 0, 1, 1)')
     ).resolves.toBeDefined();
+  });
+
+  describe('Prettier config plugins flags', () => {
+    test('ignores empty string plugin config', async () => {
+      const flags = await resolveConfigFlags(`{'plugins': ''}`);
+
+      expectNoPluginFlags(flags);
+    });
+
+    test('ignores empty list plugin config', async () => {
+      const flags = await resolveConfigFlags(`{'plugins': []}`);
+
+      expectNoPluginFlags(flags);
+    });
+
+    test('adds a string plugin path', async () => {
+      const pluginPath = '/tmp/prettier-plugin-example.js';
+      const flags = await resolveConfigFlags(
+        `{'plugins': ${vimString(pluginPath)}}`
+      );
+
+      expect(flags).toContain(`--plugin='${pluginPath}'`);
+      expect(countPluginFlags(flags)).toBe(1);
+    });
+
+    test('adds a list of plugin paths', async () => {
+      const pluginPaths = [
+        '/tmp/prettier-plugin-one.js',
+        '/tmp/prettier-plugin-two.js',
+      ];
+      const flags = await resolveConfigFlags(
+        `{'plugins': [${pluginPaths.map(vimString).join(', ')}]}`
+      );
+
+      expect(flags).toContain(`--plugin='${pluginPaths[0]}'`);
+      expect(flags).toContain(`--plugin='${pluginPaths[1]}'`);
+      expect(countPluginFlags(flags)).toBe(2);
+    });
+
+    test('ignores invalid plugin config type', async () => {
+      const flags = await resolveConfigFlags(`{'plugins': 1}`);
+
+      expectNoPluginFlags(flags);
+    });
+
+    test('shellescapes plugin paths containing spaces', async () => {
+      const pluginPath = path.join(
+        FIXTURES_DIR,
+        'plugin path',
+        'prettier-plugin-example.js'
+      );
+      const flags = await resolveConfigFlags(
+        `{'plugins': ${vimString(pluginPath)}}`
+      );
+
+      expect(flags).toContain(`--plugin='${pluginPath}'`);
+      expect(countPluginFlags(flags)).toBe(1);
+    });
+
+    test('falls back to restored global plugin config', async () => {
+      const pluginPath = '/tmp/prettier-plugin-global.js';
+
+      await remote.execute(
+        'let g:prettier_test_plugins = deepcopy(g:prettier#config#plugins)'
+      );
+
+      try {
+        await remote.execute(
+          `let g:prettier#config#plugins = ${vimString(pluginPath)}`
+        );
+
+        const flags = await resolveConfigFlags('{}');
+
+        expect(flags).toContain(`--plugin='${pluginPath}'`);
+        expect(countPluginFlags(flags)).toBe(1);
+      } finally {
+        await remote.execute(
+          'let g:prettier#config#plugins = g:prettier_test_plugins | unlet g:prettier_test_plugins'
+        );
+      }
+    });
   });
 }
 

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -7,6 +7,24 @@ const HOST = '127.0.0.1';
 const PORT = 1337;
 const FIXTURES_DIR = `${__dirname}/fixtures`;
 const VIMRC = `${__dirname}/vimrc`;
+const FORMAT_FIXTURE_LANE = process.env.PRETTIER_FORMATTING_FIXTURE_LANE || 'all';
+const QUARANTINED_FORMATTING_FIXTURES = new Set(['foo.lua', 'foo.rb']);
+
+const isSelectedFormattingFixture = file => {
+  if (FORMAT_FIXTURE_LANE === 'known-passing') {
+    return !QUARANTINED_FORMATTING_FIXTURES.has(file);
+  }
+
+  if (FORMAT_FIXTURE_LANE === 'quarantined') {
+    return QUARANTINED_FORMATTING_FIXTURES.has(file);
+  }
+
+  if (FORMAT_FIXTURE_LANE === 'all') {
+    return true;
+  }
+
+  throw new Error(`Unknown PRETTIER_FORMATTING_FIXTURE_LANE: ${FORMAT_FIXTURE_LANE}`);
+};
 
 const shellQuote = value => `'${value.replace(/'/g, `'\\''`)}'`;
 
@@ -53,7 +71,9 @@ const waitUntil = (condition, timeout = 2000) => {
 
 const assertFormatting = (file) => {
   const filename = path.basename(file);
-  test(`Prettier formats ${filename} file with :Prettier command`, async () => {
+  const formattingTest = isSelectedFormattingFixture(file) ? test : test.skip;
+
+  formattingTest(`Prettier formats ${filename} file with :Prettier command`, async () => {
     await remote.edit(`${FIXTURES_DIR}/${file}`);
 
     const lines = await getBufferContents(remote);
@@ -70,7 +90,7 @@ const assertFormatting = (file) => {
     expect(updatedLines).toMatchSnapshot();
   });
 
-  test(`Prettier formats ${filename} file with :PrettierAsync command`, async () => {
+  formattingTest(`Prettier formats ${filename} file with :PrettierAsync command`, async () => {
     await remote.edit(`${FIXTURES_DIR}/${file}`);
 
     const lines = await getBufferContents(remote);
@@ -137,12 +157,14 @@ afterEach(async () => {
 //  expect(result).toMatchSnapshot();
 //});
 
-test('Prettier config version detection works inside vim-driver execute', async () => {
-  await remote.edit(`${FIXTURES_DIR}/foo.js`);
-  await expect(
-    remote.execute('call prettier#resolver#config#resolve({}, 0, 1, 1)')
-  ).resolves.toBeDefined();
-});
+if (FORMAT_FIXTURE_LANE === 'all') {
+  test('Prettier config version detection works inside vim-driver execute', async () => {
+    await remote.edit(`${FIXTURES_DIR}/foo.js`);
+    await expect(
+      remote.execute('call prettier#resolver#config#resolve({}, 0, 1, 1)')
+    ).resolves.toBeDefined();
+  });
+}
 
 // run formatting tests in all fixtures
 fs.readdirSync(FIXTURES_DIR).forEach(file => assertFormatting(file));

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -543,6 +543,7 @@ if (FORMAT_FIXTURE_LANE === 'all') {
     test.each([
       ['PHP', 'foo.php'],
       ['XML', 'foo.xml'],
+      ['Svelte', 'foo.svelte'],
     ])('injects bundled %s plugin for bundled Prettier', async (_name, fixture) => {
       await setVimCwd(__dirname);
       await remote.edit(`${FIXTURES_DIR}/${fixture}`);
@@ -564,6 +565,7 @@ if (FORMAT_FIXTURE_LANE === 'all') {
     test.each([
       ['PHP', 'php'],
       ['XML', 'xml'],
+      ['Svelte', 'svelte'],
     ])('does not inject bundled %s plugin for project-local Prettier', async (_name, extension) => {
       const project = createProjectLocalPrettierFixture(extension);
 

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const HeadlessRemoteClient = require('vim-driver/dist/HeadlessRemoteClient');
 const Server = require('vim-driver/dist/Server');
@@ -9,6 +10,7 @@ const FIXTURES_DIR = `${__dirname}/fixtures`;
 const VIMRC = `${__dirname}/vimrc`;
 const FORMAT_FIXTURE_LANE = process.env.PRETTIER_FORMATTING_FIXTURE_LANE || 'all';
 const QUARANTINED_FORMATTING_FIXTURES = new Set(['foo.lua', 'foo.rb']);
+const tempProjectRoots = [];
 
 const isSelectedFormattingFixture = file => {
   if (FORMAT_FIXTURE_LANE === 'known-passing') {
@@ -45,6 +47,66 @@ const getBufferContents = async remote =>
   (await remote.call('getline', [1, '$'])).join('\n');
 
 const vimString = value => `'${value.replace(/'/g, "''")}'`;
+
+const removeDirectorySync = dir => {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+
+  fs.readdirSync(dir).forEach(entry => {
+    const entryPath = path.join(dir, entry);
+
+    if (fs.lstatSync(entryPath).isDirectory()) {
+      removeDirectorySync(entryPath);
+    } else {
+      fs.unlinkSync(entryPath);
+    }
+  });
+
+  fs.rmdirSync(dir);
+};
+
+const cleanupTempProjects = () => {
+  while (tempProjectRoots.length > 0) {
+    removeDirectorySync(tempProjectRoots.pop());
+  }
+};
+
+const writeFakePrettierExecutable = prettierPath => {
+  fs.writeFileSync(
+    prettierPath,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "--version" ]; then',
+      "  printf '3.0.3\\n'",
+      'fi',
+      'exit 0',
+    ].join('\n') + '\n'
+  );
+  fs.chmodSync(prettierPath, 0o755);
+};
+
+const createProjectLocalPrettierFixture = extension => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vim-prettier-local-'));
+  const binDir = path.join(root, 'node_modules', '.bin');
+  const sourceDir = path.join(root, 'src', 'nested');
+  const prettierPath = path.join(binDir, 'prettier');
+  const sourcePath = path.join(sourceDir, `index.${extension}`);
+
+  tempProjectRoots.push(root);
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.mkdirSync(sourceDir, { recursive: true });
+  writeFakePrettierExecutable(prettierPath);
+  fs.writeFileSync(
+    sourcePath,
+    extension === 'php' ? "<?php\n$foo = 'bar';\n" : "const foo = 'bar';\n"
+  );
+
+  return { root, prettierPath, sourcePath };
+};
+
+const setVimCwd = dir =>
+  remote.execute(`execute 'cd' fnameescape(${vimString(dir)})`);
 
 const resolveConfigFlags = config =>
   remote.eval(`prettier#resolver#config#resolve(${config}, 0, 1, 1)`);
@@ -148,18 +210,22 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  if (remote.isConnected()) {
-    try {
-      const filename = await remote.call('expand', ['%:p']);
+  try {
+    if (remote.isConnected()) {
+      try {
+        const filename = await remote.call('expand', ['%:p']);
 
-      if (filename) {
-        // restore the file
-        await remote.execute('earlier 1d | noautocmd | write');
+        if (filename) {
+          // restore the file
+          await remote.execute('earlier 1d | noautocmd | write');
+        }
+      } catch (e) {
+      } finally {
+        await remote.close();
       }
-    } catch (e) {
-    } finally {
-      await remote.close();
     }
+  } finally {
+    cleanupTempProjects();
   }
 });
 
@@ -254,6 +320,95 @@ if (FORMAT_FIXTURE_LANE === 'all') {
           'let g:prettier#config#plugins = g:prettier_test_plugins | unlet g:prettier_test_plugins'
         );
       }
+    });
+  });
+
+  describe('Prettier config project-local Prettier behavior', () => {
+    test('finds project-local Prettier from the buffer tree before Vim cwd', async () => {
+      const project = createProjectLocalPrettierFixture('js');
+
+      await setVimCwd(__dirname);
+      await remote.edit(project.sourcePath);
+
+      const cwd = await remote.eval('getcwd()');
+      const resolvedPath = await remote.eval(
+        'prettier#resolver#executable#getPath()'
+      );
+
+      expect(path.resolve(cwd)).toBe(path.resolve(__dirname));
+      expect(path.resolve(cwd)).not.toBe(path.resolve(project.root));
+      expect(resolvedPath).toBe(project.prettierPath);
+    });
+
+    test('continues past nested node_modules without Prettier', async () => {
+      const project = createProjectLocalPrettierFixture('js');
+      const nestedPackageDir = path.join(project.root, 'packages', 'app');
+      const nestedSourceDir = path.join(nestedPackageDir, 'src');
+      const nestedSourcePath = path.join(nestedSourceDir, 'index.js');
+
+      fs.mkdirSync(path.join(nestedPackageDir, 'node_modules'), {
+        recursive: true,
+      });
+      fs.mkdirSync(nestedSourceDir, { recursive: true });
+      fs.writeFileSync(nestedSourcePath, "const nested = 'value';\n");
+
+      await setVimCwd(__dirname);
+      await remote.edit(nestedSourcePath);
+
+      const resolvedPath = await remote.eval(
+        'prettier#resolver#executable#getPath()'
+      );
+
+      expect(resolvedPath).toBe(project.prettierPath);
+    });
+
+    test('keeps user-defined Prettier path precedence over buffer-local Prettier', async () => {
+      const project = createProjectLocalPrettierFixture('js');
+      const overrideDir = path.join(project.root, 'override-bin');
+      const overridePath = path.join(overrideDir, 'prettier');
+
+      fs.mkdirSync(overrideDir);
+      writeFakePrettierExecutable(overridePath);
+
+      await remote.execute(
+        `let g:prettier#exec_cmd_path = ${vimString(overridePath)}`
+      );
+
+      try {
+        await setVimCwd(__dirname);
+        await remote.edit(project.sourcePath);
+
+        const resolvedPath = await remote.eval(
+          'prettier#resolver#executable#getPath()'
+        );
+
+        expect(resolvedPath).toBe(overridePath);
+      } finally {
+        await remote.execute('let g:prettier#exec_cmd_path = 0');
+      }
+    });
+
+    test('does not inject bundled PHP plugin for project-local Prettier', async () => {
+      const project = createProjectLocalPrettierFixture('php');
+
+      await setVimCwd(__dirname);
+      await remote.edit(project.sourcePath);
+
+      const resolvedPath = await remote.eval(
+        'prettier#resolver#executable#getPath()'
+      );
+      const hasBundledPlugins = await remote.eval(
+        "exists('b:prettier_ft_default_args') && has_key(b:prettier_ft_default_args, 'bundledPlugins') && len(b:prettier_ft_default_args.bundledPlugins) > 0"
+      );
+      const bundledPluginPath = await remote.eval(
+        "get(b:prettier_ft_default_args, 'bundledPlugins', [''])[0]"
+      );
+      const flags = await resolveConfigFlags('b:prettier_ft_default_args');
+
+      expect(resolvedPath).toBe(project.prettierPath);
+      expect(hasBundledPlugins).toBe(1);
+      expect(flags).not.toContain(bundledPluginPath);
+      expectNoPluginFlags(flags);
     });
   });
 }

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -156,6 +156,22 @@ const createShellSafetyPrettierFixture = () => {
   return { root, prettierPath, sourcePath };
 };
 
+const createConfigDiscoveryFixture = configFileName => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vim-prettier-config-'));
+  const sourceDir = path.join(root, 'src', 'nested');
+  const sourcePath = path.join(sourceDir, 'index.js');
+
+  tempProjectRoots.push(root);
+  fs.mkdirSync(sourceDir, { recursive: true });
+  fs.writeFileSync(sourcePath, "const configDiscovery = 'value';\n");
+
+  if (configFileName) {
+    fs.writeFileSync(path.join(root, configFileName), 'export default {};\n');
+  }
+
+  return { root, sourcePath };
+};
+
 const setVimCwd = dir =>
   remote.execute(`execute 'cd' fnameescape(${vimStringExpr(dir)})`);
 
@@ -164,6 +180,9 @@ const editFile = file =>
 
 const resolveConfigFlags = config =>
   remote.eval(`prettier#resolver#config#resolve(${config}, 0, 1, 1)`);
+
+const isDefaultConfigPresent = () =>
+  remote.eval('prettier#IsConfigPresent(g:prettier#autoformat_config_files)');
 
 const expectNoPluginFlags = flags => {
   expect(flags).not.toContain('--plugin=');
@@ -482,6 +501,33 @@ if (FORMAT_FIXTURE_LANE === 'all') {
       expect(hasBundledPlugins).toBe(1);
       expect(flags).not.toContain(bundledPluginPath);
       expectNoPluginFlags(flags);
+    });
+  });
+
+  describe('Prettier config file discovery', () => {
+    test('detects modern config names from the buffer project tree', async () => {
+      const project = createConfigDiscoveryFixture('prettier.config.mjs');
+
+      await setVimCwd(__dirname);
+      await editFile(project.sourcePath);
+
+      const cwd = await remote.eval('getcwd()');
+      const isConfigPresent = await isDefaultConfigPresent();
+
+      expect(path.resolve(cwd)).toBe(path.resolve(__dirname));
+      expect(path.resolve(cwd)).not.toBe(path.resolve(project.root));
+      expect(isConfigPresent).toBe(1);
+    });
+
+    test('does not detect missing config from the buffer project tree', async () => {
+      const project = createConfigDiscoveryFixture();
+
+      await setVimCwd(__dirname);
+      await editFile(project.sourcePath);
+
+      const isConfigPresent = await isDefaultConfigPresent();
+
+      expect(isConfigPresent).toBe(0);
     });
   });
 

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const HeadlessRemoteClient = require('vim-driver/dist/HeadlessRemoteClient');
-const Server = require('vim-driver/dist/Server');
+const HeadlessRemoteClient = require('./vim-driver/HeadlessRemoteClient');
+const Server = require('./vim-driver/Server');
 
 const HOST = '127.0.0.1';
 const PORT = Number(process.env.VIM_DRIVER_PORT || 10000 + (process.pid % 50000));
+const REPO_ROOT = path.resolve(__dirname, '..');
 const FIXTURES_DIR = `${__dirname}/fixtures`;
 const VIMRC = `${__dirname}/vimrc`;
 const FORMAT_FIXTURE_LANE = process.env.PRETTIER_FORMATTING_FIXTURE_LANE || 'all';
@@ -49,6 +50,7 @@ const shellQuote = value => `'${value.replace(/'/g, `'\\''`)}'`;
 
 const vimExecutable = [
   process.env.VIM_EXECUTABLE || 'vim',
+  process.env.VIM_EXECUTABLE_ARGS || '',
   '-Nu',
   shellQuote(VIMRC),
   '-n',
@@ -553,8 +555,8 @@ if (FORMAT_FIXTURE_LANE === 'all') {
       );
       const flags = await resolveConfigFlags('b:prettier_ft_default_args');
 
-      expect(resolvedPath).toContain(path.join('vim-prettier', 'node_modules'));
-      expect(bundledPluginPath).toContain(path.join('vim-prettier', 'node_modules'));
+      expect(resolvedPath).toBe(path.join(REPO_ROOT, 'node_modules', '.bin', 'prettier'));
+      expect(bundledPluginPath).toContain(path.join(REPO_ROOT, 'node_modules'));
       expect(flags).toContain(`--plugin='${bundledPluginPath}'`);
       expect(countPluginFlags(flags)).toBe(1);
     });

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -251,6 +251,14 @@ const expectNoPluginFlags = flags => {
 const countPluginFlags = flags => (flags.match(/--plugin=/g) || []).length;
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+const timeoutAfter = (promise, ms) => {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout));
+};
 const waitUntil = (condition, timeout = 2000) => {
   return new Promise(resolve => {
     let isTimedOut = false;
@@ -346,18 +354,17 @@ afterEach(async () => {
   try {
     if (remote.isConnected()) {
       try {
-        const filename = await remote.call('expand', ['%:p']);
+        const filename = await timeoutAfter(remote.call('expand', ['%:p']), 5000);
 
         if (filename) {
           // restore the file
-          await remote.execute('earlier 1d | noautocmd | write');
+          await timeoutAfter(remote.execute('earlier 1d | noautocmd | write'), 5000);
         }
       } catch (e) {
-      } finally {
-        await remote.close();
       }
     }
   } finally {
+    await timeoutAfter(remote.close(), 5000).catch(() => {});
     cleanupTempProjects();
   }
 });

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -9,6 +9,19 @@ const PORT = 1337;
 const FIXTURES_DIR = `${__dirname}/fixtures`;
 const VIMRC = `${__dirname}/vimrc`;
 const FORMAT_FIXTURE_LANE = process.env.PRETTIER_FORMATTING_FIXTURE_LANE || 'all';
+const CORE_FORMATTING_FIXTURES = new Set([
+  'foo.css',
+  'foo.graphql',
+  'foo.html',
+  'foo.js',
+  'foo.json',
+  'foo.less',
+  'foo.md',
+  'foo.scss',
+  'foo.ts',
+  'foo.vue',
+  'foo.yaml',
+]);
 const QUARANTINED_FORMATTING_FIXTURES = new Set(['foo.lua', 'foo.rb']);
 const tempProjectRoots = [];
 
@@ -19,6 +32,10 @@ const isSelectedFormattingFixture = file => {
 
   if (FORMAT_FIXTURE_LANE === 'quarantined') {
     return QUARANTINED_FORMATTING_FIXTURES.has(file);
+  }
+
+  if (FORMAT_FIXTURE_LANE === 'core') {
+    return CORE_FORMATTING_FIXTURES.has(file);
   }
 
   if (FORMAT_FIXTURE_LANE === 'all') {

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -242,6 +242,25 @@ if (FORMAT_FIXTURE_LANE === 'all') {
     ).resolves.toBeDefined();
   });
 
+  test('Prettier config overrides do not mutate buffer filetype defaults', async () => {
+    await remote.edit(`${FIXTURES_DIR}/foo.css`);
+    await remote.execute('let b:prettier_test_original_args = deepcopy(b:prettier_ft_default_args)');
+
+    try {
+      await remote.execute(
+        "call prettier#Prettier(0, 1, line('$'), 0, {'singleQuote': 'false'})"
+      );
+
+      const defaultsUnchanged = await remote.eval(
+        'b:prettier_ft_default_args ==# b:prettier_test_original_args'
+      );
+
+      expect(defaultsUnchanged).toBe(1);
+    } finally {
+      await remote.execute('unlet b:prettier_test_original_args');
+    }
+  });
+
   describe('Prettier config plugins flags', () => {
     test('ignores empty string plugin config', async () => {
       const flags = await resolveConfigFlags(`{'plugins': ''}`);

--- a/tests/formatting.test.js
+++ b/tests/formatting.test.js
@@ -6,6 +6,17 @@ const Server = require('vim-driver/dist/Server');
 const HOST = '127.0.0.1';
 const PORT = 1337;
 const FIXTURES_DIR = `${__dirname}/fixtures`;
+const VIMRC = `${__dirname}/vimrc`;
+
+const shellQuote = value => `'${value.replace(/'/g, `'\\''`)}'`;
+
+const vimExecutable = [
+  process.env.VIM_EXECUTABLE || 'vim',
+  '-Nu',
+  shellQuote(VIMRC),
+  '-n',
+  '-i NONE',
+].join(' ');
 
 let server;
 let remote;
@@ -97,7 +108,11 @@ afterAll(async () => {
 // should ensure that we cache original fixture contents and
 // restore it on the afterEach
 beforeEach(async () => {
-  remote = new HeadlessRemoteClient({host: HOST, port: PORT});
+  remote = new HeadlessRemoteClient({
+    executable: vimExecutable,
+    host: HOST,
+    port: PORT,
+  });
   await remote.connect(server);
 });
 
@@ -121,6 +136,13 @@ afterEach(async () => {
 //  const result = await remote.execute('PrettierVersion');
 //  expect(result).toMatchSnapshot();
 //});
+
+test('Prettier config version detection works inside vim-driver execute', async () => {
+  await remote.edit(`${FIXTURES_DIR}/foo.js`);
+  await expect(
+    remote.execute('call prettier#resolver#config#resolve({}, 0, 1, 1)')
+  ).resolves.toBeDefined();
+});
 
 // run formatting tests in all fixtures
 fs.readdirSync(FIXTURES_DIR).forEach(file => assertFormatting(file));

--- a/tests/vim-driver/HeadlessRemoteClient.js
+++ b/tests/vim-driver/HeadlessRemoteClient.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const RemoteClient = require('./RemoteClient');
+const VimProcess = require('./VimProcess');
+const { createLogger } = require('./Logger');
+
+const DEFAULT_EXEC = 'vim';
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8765;
+const DEFAULT_CONNECT_TIMEOUT = 10000;
+
+const Logger = createLogger('vim-driver');
+let nextClientId = 0;
+
+class HeadlessRemoteClient {
+  constructor(opts = {}) {
+    nextClientId += 1;
+    this._id = `vim-prettier-test-${process.pid}-${nextClientId}`;
+    this._opts = opts;
+    this._subscribers = [];
+    this._remoteAssignmentSubscribers = [];
+  }
+
+  getId() {
+    return this._id;
+  }
+
+  isConnected() {
+    const remote = this._remote;
+    return remote != null ? remote.isConnected() : false;
+  }
+
+  connect(server) {
+    return new Promise((resolve, reject) => {
+      if (this._remote != null) {
+        Logger.warn(`Failed to connect to server. Client ${this._id} is already connected to a server.`);
+        reject('HeadlessRemoteClient is already connected.');
+        return;
+      }
+
+      const subscription = server.subscribe({
+        onConnect: remote => {
+          if (settled) {
+            return;
+          }
+          if (remote.getId() === this._id) {
+            cleanup();
+            this._assignRemote(remote);
+            resolve(this);
+          }
+        },
+      });
+
+      let settled = false;
+      let processSubscription;
+      let timeout;
+      const cleanup = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        subscription.unsubscribe();
+        if (processSubscription) {
+          processSubscription.unsubscribe();
+        }
+      };
+
+      const fail = async error => {
+        if (settled) {
+          return;
+        }
+        cleanup();
+        if (this._vimProcess != null) {
+          await this._vimProcess.kill();
+          this._vimProcess = null;
+        }
+        reject(error);
+      };
+
+      const opts = this._opts;
+      this._vimProcess = new VimProcess(this._id, {
+        executable: opts.executable != null ? opts.executable : DEFAULT_EXEC,
+        host: opts.host != null ? opts.host : DEFAULT_HOST,
+        port: opts.port != null ? opts.port : DEFAULT_PORT,
+      });
+      processSubscription = this._vimProcess.subscribe({
+        onError: error => {
+          fail(error);
+        },
+        onExit: (code, signal) => {
+          fail(new Error(`Vim process exited before connecting: code=${code}, signal=${signal}`));
+        },
+      });
+      timeout = setTimeout(() => {
+        const output = this._vimProcess != null ? this._vimProcess.getOutput() : '';
+        const outputMessage = output ? `\nEditor output:\n${output}` : '';
+        fail(new Error(`Timed out connecting HeadlessRemoteClient ${this._id}${outputMessage}`));
+      }, opts.connectTimeout != null ? opts.connectTimeout : DEFAULT_CONNECT_TIMEOUT);
+    });
+  }
+
+  async call(name, arglist) {
+    this._assertConnected('call');
+    return this._remote.call(name, arglist);
+  }
+
+  async edit(path) {
+    this._assertConnected('edit');
+    return this._remote.edit(path);
+  }
+
+  async eval(string) {
+    this._assertConnected('eval');
+    return this._remote.eval(string);
+  }
+
+  async execute(command) {
+    this._assertConnected('execute');
+    return this._remote.execute(command);
+  }
+
+  async close() {
+    this._assertConnected('close');
+    await this._remote.close();
+    if (this._vimProcess != null) {
+      await this._vimProcess.kill();
+    }
+    this._unassignRemote();
+    return this;
+  }
+
+  async send(payload) {
+    this._assertConnected('send');
+    return this._remote.send(payload);
+  }
+
+  subscribe(subscriber) {
+    const subscribers = this._subscribers;
+    subscribers.push(subscriber);
+
+    let remoteSubscription;
+    if (this._remote != null) {
+      remoteSubscription = this._remote.subscribe(subscriber);
+    }
+
+    const remoteAssignmentObserver = this._subscribeRemoteAssignment({
+      onAssign: remote => {
+        if (remoteSubscription) {
+          remoteSubscription.unsubscribe();
+        }
+        remoteSubscription = remote.subscribe(subscriber);
+      },
+      onUnassign: () => {
+        if (remoteSubscription) {
+          remoteSubscription.unsubscribe();
+          remoteSubscription = null;
+        }
+      },
+    });
+
+    return {
+      unsubscribe: () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index !== -1) {
+          subscribers.splice(index, 1);
+        }
+
+        remoteAssignmentObserver.unsubscribe();
+
+        if (remoteSubscription) {
+          remoteSubscription.unsubscribe();
+        }
+      },
+    };
+  }
+
+  _assertConnected(action) {
+    if (this._remote == null) {
+      const msg = `HeadlessRemoteClient ${this._id} not connected. Failed to ${action}.`;
+      Logger.error(msg);
+      throw msg;
+    }
+  }
+
+  _assignRemote(remote) {
+    this._remote = remote;
+    this._remoteAssignmentSubscribers.forEach(subscriber => {
+      if (subscriber.onAssign) {
+        subscriber.onAssign(remote);
+      }
+    });
+    this._subscribers.forEach(subscriber => {
+      if (subscriber.onConnect) {
+        subscriber.onConnect();
+      }
+    });
+  }
+
+  _unassignRemote() {
+    if (this._remote == null) {
+      return;
+    }
+
+    const remote = this._remote;
+    this._remote = null;
+    this._remoteAssignmentSubscribers.forEach(subscriber => {
+      if (subscriber.onUnassign) {
+        subscriber.onUnassign(remote);
+      }
+    });
+  }
+
+  _subscribeRemoteAssignment(subscriber) {
+    const subscribers = this._remoteAssignmentSubscribers;
+    subscribers.push(subscriber);
+    return {
+      unsubscribe: () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index !== -1) {
+          subscribers.splice(index, 1);
+        }
+      },
+    };
+  }
+}
+
+module.exports = HeadlessRemoteClient;

--- a/tests/vim-driver/HeadlessRemoteClient.js
+++ b/tests/vim-driver/HeadlessRemoteClient.js
@@ -121,12 +121,17 @@ class HeadlessRemoteClient {
   }
 
   async close() {
-    this._assertConnected('close');
-    await this._remote.close();
-    if (this._vimProcess != null) {
-      await this._vimProcess.kill();
+    try {
+      if (this._remote != null) {
+        await this._remote.close();
+      }
+    } finally {
+      if (this._vimProcess != null) {
+        await this._vimProcess.kill();
+        this._vimProcess = null;
+      }
+      this._unassignRemote();
     }
-    this._unassignRemote();
     return this;
   }
 

--- a/tests/vim-driver/LICENSE
+++ b/tests/vim-driver/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2018 Sam Howie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/vim-driver/Logger.js
+++ b/tests/vim-driver/Logger.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const colors = require('colors/safe');
+
+const LOG_LEVEL = {
+  trace: 5,
+  debug: 4,
+  info: 3,
+  warn: 2,
+  error: 1,
+  fatal: 0,
+};
+
+const isLogLevelPermission = level => {
+  const envLevel = LOG_LEVEL[process.env.LOG_LEVEL || 'warn'];
+  return (envLevel != null ? envLevel : LOG_LEVEL.warn) >= level;
+};
+
+const noop = () => {};
+
+const createLogger = name => ({
+  trace: isLogLevelPermission(LOG_LEVEL.trace) ? console.log.bind(console, colors.green.grey(`[${name}|trace]`)) : noop,
+  debug: isLogLevelPermission(LOG_LEVEL.debug) ? console.log.bind(console, colors.blue.bold(`[${name}|debug]`)) : noop,
+  info: isLogLevelPermission(LOG_LEVEL.info) ? console.log.bind(console, colors.green.bold(`[${name}|info]`)) : noop,
+  warn: isLogLevelPermission(LOG_LEVEL.warn) ? console.log.bind(console, colors.yellow.bold(`[${name}|warn]`)) : noop,
+  error: isLogLevelPermission(LOG_LEVEL.error) ? console.log.bind(console, colors.red.bold(`[${name}|error]`)) : noop,
+  fatal: isLogLevelPermission(LOG_LEVEL.fatal) ? console.log.bind(console, colors.red.bold(`[${name}|fatal]`)) : noop,
+});
+
+module.exports = {
+  createLogger,
+};

--- a/tests/vim-driver/README.md
+++ b/tests/vim-driver/README.md
@@ -1,0 +1,9 @@
+# Test Vim Driver
+
+This is the small subset of `vim-driver@1.0.1` used by the Jest formatting
+harness, adapted locally under the same MIT license as the upstream package.
+See `LICENSE` for upstream attribution.
+
+The local copy avoids the unused `shortid -> nanoid` dependency path by using
+deterministic process-local counters for client and request IDs. It is test-only
+infrastructure and is not part of vim-prettier runtime behavior.

--- a/tests/vim-driver/RemoteClient.js
+++ b/tests/vim-driver/RemoteClient.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const RequestManager = require('./RequestManager');
+
+class RemoteClient {
+  constructor(id, socket) {
+    this._onClose = () => {
+      this._requestManager.destroy();
+      this._removeListeners();
+      this._subscribers.forEach(subscriber => {
+        if (subscriber.onClose) {
+          subscriber.onClose();
+        }
+      });
+    };
+
+    this._onData = () => {};
+
+    this._onEnd = () => {
+      this.close();
+    };
+
+    this._onError = error => {
+      this._subscribers.forEach(subscriber => {
+        if (subscriber.onError) {
+          subscriber.onError(error);
+        }
+      });
+    };
+
+    this._id = id;
+    this._socket = socket;
+    this._subscribers = [];
+    this._requestManager = new RequestManager(id, socket);
+    this._addListeners();
+  }
+
+  getId() {
+    return this._id;
+  }
+
+  async call(name, arglist) {
+    const response = await this._requestManager.send({ type: 'command:call', name, arglist });
+    if (response.error) {
+      throw response.error;
+    }
+    return response.result;
+  }
+
+  async edit(path) {
+    const response = await this._requestManager.send({ type: 'command:edit', path });
+    if (response.error) {
+      throw response.error;
+    }
+    return null;
+  }
+
+  async eval(string) {
+    const response = await this._requestManager.send({ type: 'command:eval', string });
+    if (response.error) {
+      throw response.error;
+    }
+    return response.result;
+  }
+
+  async execute(command) {
+    const response = await this._requestManager.send({ type: 'command:execute', command });
+    if (response.error) {
+      throw response.error;
+    }
+    return response.result;
+  }
+
+  close() {
+    return new Promise(resolve => {
+      this._socket.destroy();
+      this._onClose();
+      resolve(this);
+    });
+  }
+
+  isConnected() {
+    return !this._socket.destroyed;
+  }
+
+  async send(payload) {
+    return this._requestManager.send(payload);
+  }
+
+  subscribe(subscriber) {
+    const subscribers = this._subscribers;
+    subscribers.push(subscriber);
+    return {
+      unsubscribe: () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index !== -1) {
+          subscribers.splice(index, 1);
+        }
+      },
+    };
+  }
+
+  _addListeners() {
+    const socket = this._socket;
+    socket.addListener('close', this._onClose);
+    socket.addListener('data', this._onData);
+    socket.addListener('end', this._onEnd);
+    socket.addListener('error', this._onError);
+  }
+
+  _removeListeners() {
+    const socket = this._socket;
+    socket.removeListener('close', this._onClose);
+    socket.removeListener('data', this._onData);
+    socket.removeListener('end', this._onEnd);
+    socket.removeListener('error', this._onError);
+  }
+}
+
+module.exports = RemoteClient;

--- a/tests/vim-driver/RequestManager.js
+++ b/tests/vim-driver/RequestManager.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { createLogger } = require('./Logger');
+
+const Logger = createLogger('vim-driver');
+
+class RequestManager {
+  constructor(id, socket) {
+    this._onData = rawData => {
+      this._buffer += rawData.toString();
+
+      let newlineIndex = this._buffer.indexOf('\n');
+      while (newlineIndex !== -1) {
+        const rawMessage = this._buffer.slice(0, newlineIndex);
+        this._buffer = this._buffer.slice(newlineIndex + 1);
+        newlineIndex = this._buffer.indexOf('\n');
+
+        if (rawMessage === '') {
+          continue;
+        }
+
+        let message;
+        try {
+          message = JSON.parse(rawMessage);
+        } catch (error) {
+          this._rejectPendingRequests(error);
+          continue;
+        }
+        const messageId = message[0];
+        const resolver = this._pendingRequests[messageId];
+
+        if (resolver == null) {
+          Logger.error(`client ${this._id} received an unknown message: ${rawMessage}`);
+          continue;
+        }
+
+        delete this._pendingRequests[messageId];
+
+        const messagePayload = message[1];
+        Logger.debug(`client: ${this._id}, message-in: ${rawMessage}`);
+        resolver.resolve(messagePayload);
+      }
+    };
+
+    this._onClose = () => {
+      this._rejectPendingRequests(new Error(`client ${this._id} socket closed`));
+      this._removeListeners();
+    };
+
+    this._onEnd = () => {
+      this._rejectPendingRequests(new Error(`client ${this._id} socket ended`));
+    };
+
+    this._onError = error => {
+      this._rejectPendingRequests(error);
+    };
+
+    this._id = id;
+    this._socket = socket;
+    this._buffer = '';
+    this._pendingRequests = {};
+    this._nextRequestId = 0;
+    this._addListeners();
+  }
+
+  send(payload) {
+    return new Promise((resolve, reject) => {
+      this._nextRequestId += 1;
+      const requestId = `${this._id}-${this._nextRequestId}`;
+
+      this._pendingRequests[requestId] = { resolve, reject };
+
+      const rawMessage = JSON.stringify([requestId, payload]);
+      Logger.debug(`client: ${this._id}, message-out: ${rawMessage}`);
+      this._socket.write(rawMessage + '\n', error => {
+        if (error) {
+          delete this._pendingRequests[requestId];
+          reject(error);
+        }
+      });
+    });
+  }
+
+  _addListeners() {
+    this._socket.addListener('data', this._onData);
+    this._socket.addListener('close', this._onClose);
+    this._socket.addListener('end', this._onEnd);
+    this._socket.addListener('error', this._onError);
+  }
+
+  _removeListeners() {
+    this._socket.removeListener('data', this._onData);
+    this._socket.removeListener('close', this._onClose);
+    this._socket.removeListener('end', this._onEnd);
+    this._socket.removeListener('error', this._onError);
+  }
+
+  _rejectPendingRequests(error) {
+    const pendingRequests = this._pendingRequests;
+    this._pendingRequests = {};
+    Object.keys(pendingRequests).forEach(requestId => {
+      pendingRequests[requestId].reject(error);
+    });
+  }
+
+  destroy() {
+    this._rejectPendingRequests(new Error(`client ${this._id} request manager destroyed`));
+    this._removeListeners();
+  }
+}
+
+module.exports = RequestManager;

--- a/tests/vim-driver/Server.js
+++ b/tests/vim-driver/Server.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const net = require('net');
+
+const identifyClient = require('./identifyClient');
+const { createLogger } = require('./Logger');
+const RemoteClient = require('./RemoteClient');
+
+const Logger = createLogger('vim-driver');
+
+class Server {
+  constructor() {
+    this._onClose = () => {
+      this._pendingIdentifications.forEach(identification => identification.cancel());
+      this._pendingIdentifications.length = 0;
+      this._subscribers.forEach(subscriber => {
+        if (subscriber.onClose != null) {
+          subscriber.onClose();
+        }
+      });
+    };
+
+    this._onConnection = socket => {
+      const pendingIdentifications = this._pendingIdentifications;
+
+      let abort;
+      const abortPromise = new Promise(resolve => {
+        abort = resolve;
+      });
+
+      const cancel = {
+        cancel: () => {
+          abort();
+        },
+      };
+      pendingIdentifications.push(cancel);
+
+      const removePendingIdentifcation = () => {
+        const index = pendingIdentifications.indexOf(cancel);
+        if (index !== -1) {
+          pendingIdentifications.splice(index, 1);
+        }
+      };
+
+      identifyClient(socket, abortPromise).then(
+        ([identifiedSocket, id]) => {
+          Logger.debug(`client connected as: ${id}`);
+          this._onIdentification(identifiedSocket, id);
+          removePendingIdentifcation();
+        },
+        err => {
+          Logger.error('client identification error:\n' + err);
+          removePendingIdentifcation();
+          socket.destroy();
+        }
+      );
+    };
+
+    this._onIdentification = (socket, id) => {
+      const remote = new RemoteClient(id, socket);
+      remote.subscribe({
+        onClose: () => {
+          this._removeRemote(remote);
+        },
+      });
+      this._addRemote(remote);
+    };
+
+    this._onError = error => {
+      Logger.error(error.message);
+      this._subscribers.forEach(subscriber => {
+        if (subscriber.onError != null) {
+          subscriber.onError(error);
+        }
+      });
+    };
+
+    this._pendingIdentifications = [];
+    this._remotes = [];
+    this._server = net.createServer();
+    this._subscribers = [];
+    this._addServerListeners(this._server);
+  }
+
+  close() {
+    return new Promise(resolve => {
+      this._remotes.map(remote => remote.close());
+      this._remotes.length = 0;
+      this._server.close(() => resolve(this));
+    });
+  }
+
+  isListening() {
+    return this._server.listening;
+  }
+
+  listen(host, port) {
+    return new Promise((resolve, reject) => {
+      if (this._server.listening) {
+        reject('server already open');
+        return;
+      }
+      this._server.listen({ host, port }, () => {
+        Logger.info(`server is listening on: ${host}:${port}`);
+        resolve(this);
+      });
+    });
+  }
+
+  subscribe(subscriber) {
+    const subscribers = this._subscribers;
+    this._subscribers.push(subscriber);
+    return {
+      unsubscribe: () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index !== -1) {
+          subscribers.splice(index, 1);
+        }
+      },
+    };
+  }
+
+  _addServerListeners(server) {
+    server.addListener('close', this._onClose);
+    server.addListener('connection', this._onConnection);
+    server.addListener('error', this._onError);
+  }
+
+  _addRemote(remote) {
+    this._remotes.push(remote);
+    this._subscribers.forEach(subscriber => {
+      if (subscriber.onConnect != null) {
+        subscriber.onConnect(remote);
+      }
+    });
+  }
+
+  _removeRemote(remote) {
+    const index = this._remotes.indexOf(remote);
+    if (index !== -1) {
+      this._remotes.splice(index, 1);
+    }
+  }
+}
+
+module.exports = Server;

--- a/tests/vim-driver/VimDriverClient.vim
+++ b/tests/vim-driver/VimDriverClient.vim
@@ -1,0 +1,152 @@
+let g:vim_driver_client_id = 'undefined'
+let g:vim_driver_client_buffer = ''
+
+function! s:info(message) abort
+  echohl MoreMsg | echom 'vim-driver: ' . a:message | echohl
+endfunction
+
+function! s:warn(message) abort
+  echohl WarningMsg | echom 'vim-driver: ' . a:message | echohl
+endfunction
+
+function! s:send(channel, raw_message) abort
+  if has('nvim')
+    call chansend(a:channel, a:raw_message)
+  else
+    call ch_sendraw(a:channel, a:raw_message)
+  endif
+endfunction
+
+function! g:VimDriverClient#open(host, port) abort
+  try
+    if !has('nvim') && has('channel') !=# 1
+      call s:warn('channel not supported')
+      return
+    endif
+
+    if exists('g:vim_driver_client_channel')
+      call s:warn('client already open')
+      return
+    endif
+
+    let l:address = a:host . ':' . a:port
+    if has('nvim')
+      let l:channel = sockconnect('tcp', l:address, {
+            \ 'mode': 'nl',
+            \ 'on_data': 'VimDriverClient#__onNvimData'})
+    else
+      let l:channel_opts = {
+            \ 'mode': 'nl',
+            \ 'callback': 'VimDriverClient#__onMessage',
+            \ 'close_cb': 'VimDriverClient#__onClose'}
+
+      if v:version >= 800
+        let l:channel_opts.drop = 'never'
+      endif
+
+      let l:channel = ch_open(l:address, l:channel_opts)
+    endif
+    let g:vim_driver_client_channel = l:channel
+
+    if has('nvim') ? l:channel <= 0 : ch_status(l:channel) !=# 'open'
+      call s:warn('failed to open channel')
+      unlet g:vim_driver_client_channel
+    else
+      call s:info('opened channel on ' . a:host . ':' . a:port)
+      call s:send(l:channel, json_encode(['$id', {'id': g:vim_driver_client_id}]) . "\n")
+    endif
+  catch
+    call s:warn('failed to open channel: ' . v:exception)
+  endtry
+endfunction
+
+function! g:VimDriverClient#close() abort
+  try
+    if exists('g:vim_driver_client_channel')
+      if !has('nvim') && ch_status(g:vim_driver_client_channel) !=# 'open'
+        unlet g:vim_driver_client_channel
+        return
+      endif
+
+      if has('nvim')
+        call chanclose(g:vim_driver_client_channel)
+      else
+        call ch_close(g:vim_driver_client_channel)
+      endif
+      unlet g:vim_driver_client_channel
+      call s:info('closed channel')
+    else
+      call s:warn('channel already closed')
+    endif
+  catch
+    call s:warn('failed to close channel')
+  endtry
+endfunction
+
+function! g:VimDriverClient#__onNvimData(channel, data, event) abort
+  for l:raw_message in a:data
+    if l:raw_message !=# ''
+      call VimDriverClient#__onMessage(a:channel, l:raw_message)
+    endif
+  endfor
+endfunction
+
+function! g:VimDriverClient#__onMessage(channel, raw_message) abort
+  try
+    let l:message = json_decode(a:raw_message)
+    let l:id = l:message[0]
+    let l:payload = l:message[1]
+    let l:type = l:payload.type
+
+    if l:type ==# 'command:call'
+      call s:onCall(a:channel, l:id, l:payload)
+    elseif l:type ==# 'command:edit'
+      call s:onEdit(a:channel, l:id, l:payload)
+    elseif l:type ==# 'command:eval'
+      call s:onEval(a:channel, l:id, l:payload)
+    elseif l:type ==# 'command:execute'
+      call s:onExecute(a:channel, l:id, l:payload)
+    elseif l:type ==# 'whois'
+      call s:onWhoIs(a:channel, l:id, l:payload)
+    endif
+  catch
+    call s:warn(v:exception)
+    call s:send(a:channel, json_encode([l:id, {'error': v:exception}]) . "\n")
+  endtry
+endfunction
+
+function! g:VimDriverClient#__onClose(channel) abort
+  call s:info('client closed remotely')
+  call VimDriverClient#close()
+endfunction
+
+function! s:escape(string) abort
+  return eval('"' . a:string . '"')
+endfunction
+
+function! s:onCall(channel, id, payload) abort
+  let l:name = a:payload.name
+  let l:arglist = a:payload.arglist
+  let l:result = call(l:name, map(l:arglist, {_key, val -> s:escape(val)}))
+  call s:send(a:channel, json_encode([a:id, {'result': l:result}]) . "\n")
+endfunction
+
+function! s:onEdit(channel, id, payload) abort
+  call execute('edit ' . a:payload.path)
+  call s:send(a:channel, json_encode([a:id, {}]) . "\n")
+endfunction
+
+function! s:onEval(channel, id, payload) abort
+  let l:result = eval(a:payload.string)
+  call s:send(a:channel, json_encode([a:id, {'result': l:result}]) . "\n")
+endfunction
+
+function! s:onExecute(channel, id, payload) abort
+  let l:result = execute(s:escape(a:payload.command))
+  let l:result = substitute(l:result, "^\n", '', '')
+  call s:send(a:channel, json_encode([a:id, {'result': l:result}]) . "\n")
+endfunction
+
+function! s:onWhoIs(channel, id, _payload) abort
+  call s:send(a:channel, json_encode([a:id, {'id': g:vim_driver_client_id}]) . "\n")
+endfunction

--- a/tests/vim-driver/VimProcess.js
+++ b/tests/vim-driver/VimProcess.js
@@ -73,10 +73,20 @@ class VimProcess {
         resolve(this);
         return;
       }
-      const onClose = () => {
-        child.removeListener('close', onClose);
-        child.removeListener('exit', onClose);
+      let resolved = false;
+      let killTimeout;
+      const finish = () => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        clearTimeout(killTimeout);
+        child.removeListener('close', finish);
+        child.removeListener('exit', finish);
         resolve(this);
+      };
+      const onClose = () => {
+        finish();
       };
       child.addListener('close', onClose);
       child.addListener('exit', onClose);
@@ -85,6 +95,14 @@ class VimProcess {
       } catch (error) {
         child.kill();
       }
+      killTimeout = setTimeout(() => {
+        try {
+          global.process.kill(-child.pid, 'SIGKILL');
+        } catch (error) {
+          child.kill('SIGKILL');
+        }
+        finish();
+      }, 2000);
     });
   }
 }

--- a/tests/vim-driver/VimProcess.js
+++ b/tests/vim-driver/VimProcess.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+class VimProcess {
+  constructor(id, opts) {
+    this._subscribers = [];
+    this._exited = false;
+    this._output = '';
+
+    const commands = [];
+
+    const sourcePath = path.join(__dirname, './VimDriverClient.vim');
+    commands.push(`source ${sourcePath}`);
+
+    if (id != null) {
+      commands.push(`let g:vim_driver_client_id = '${id}'`);
+    }
+
+    commands.push(`call VimDriverClient#open('${opts.host}', ${opts.port})`);
+
+    const shellCommand = `${opts.executable} -c ":${commands.join('|')}"`;
+    this._process = spawn(shellCommand, { detached: true, shell: true, stdio: ['pipe', 'pipe', 'pipe'] });
+    this._process.stdout.addListener('data', data => {
+      this._appendOutput(data);
+    });
+    this._process.stderr.addListener('data', data => {
+      this._appendOutput(data);
+    });
+    this._process.addListener('error', error => {
+      this._subscribers.forEach(subscriber => {
+        if (subscriber.onError) {
+          subscriber.onError(error);
+        }
+      });
+    });
+    this._process.addListener('exit', (code, signal) => {
+      this._exited = true;
+      this._subscribers.forEach(subscriber => {
+        if (subscriber.onExit) {
+          subscriber.onExit(code, signal);
+        }
+      });
+    });
+  }
+
+  subscribe(subscriber) {
+    const subscribers = this._subscribers;
+    subscribers.push(subscriber);
+    return {
+      unsubscribe: () => {
+        const index = subscribers.indexOf(subscriber);
+        if (index !== -1) {
+          subscribers.splice(index, 1);
+        }
+      },
+    };
+  }
+
+  getOutput() {
+    return this._output;
+  }
+
+  _appendOutput(data) {
+    this._output = `${this._output}${data.toString()}`.slice(-4000);
+  }
+
+  async kill() {
+    return new Promise(resolve => {
+      const child = this._process;
+      if (this._exited || child.killed) {
+        resolve(this);
+        return;
+      }
+      const onClose = () => {
+        child.removeListener('close', onClose);
+        child.removeListener('exit', onClose);
+        resolve(this);
+      };
+      child.addListener('close', onClose);
+      child.addListener('exit', onClose);
+      try {
+        global.process.kill(-child.pid, 'SIGTERM');
+      } catch (error) {
+        child.kill();
+      }
+    });
+  }
+}
+
+module.exports = VimProcess;

--- a/tests/vim-driver/identifyClient.js
+++ b/tests/vim-driver/identifyClient.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const identifyClient = (socket, abort) =>
+  new Promise((resolve, reject) => {
+    let buffer = '';
+    let resolved = false;
+    let settled = false;
+
+    const removeListeners = () => {
+      socket.removeListener('data', onData);
+      socket.removeListener('close', onClose);
+      socket.removeListener('end', onEnd);
+      socket.removeListener('error', onError);
+    };
+
+    const fail = error => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      removeListeners();
+      reject(error);
+    };
+
+    const onData = rawData => {
+      buffer += rawData.toString();
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex === -1) {
+        return;
+      }
+
+      const rawMessage = buffer.slice(0, newlineIndex);
+      const remaining = buffer.slice(newlineIndex + 1);
+
+      if (remaining !== '') {
+        fail(new Error('received unexpected client identification'));
+        return;
+      }
+
+      let message;
+      try {
+        message = JSON.parse(rawMessage);
+      } catch (error) {
+        fail(error);
+        return;
+      }
+      const messageId = message[0];
+      const messagePayload = message[1];
+      const clientId = messagePayload && messagePayload.id;
+
+      if (messageId !== '$id' || clientId == null) {
+        fail(new Error('received unexpected client identification'));
+      } else {
+        settled = true;
+        resolved = true;
+        removeListeners();
+        resolve([socket, clientId]);
+      }
+    };
+
+    const onClose = () => {
+      fail(new Error('pending client identification socket closed'));
+    };
+
+    const onEnd = () => {
+      fail(new Error('pending client identification socket ended'));
+    };
+
+    const onError = error => {
+      fail(error);
+    };
+
+    socket.addListener('data', onData);
+    socket.addListener('close', onClose);
+    socket.addListener('end', onEnd);
+    socket.addListener('error', onError);
+
+    abort.then(() => {
+      if (resolved) {
+        return;
+      }
+      fail(new Error('pending client identification was aborted'));
+    });
+  });
+
+module.exports = identifyClient;

--- a/tests/vimrc
+++ b/tests/vimrc
@@ -32,6 +32,7 @@ set tabstop=4
 set softtabstop=4
 set shiftwidth=4
 set expandtab
+autocmd FileType graphql setlocal shiftwidth=4 tabstop=4 softtabstop=4
 set backspace=2
 set nofoldenable
 set foldmethod=syntax

--- a/tests/vimrc
+++ b/tests/vimrc
@@ -1,13 +1,17 @@
 " vint: -ProhibitSetNoCompatible
 
-source /rtp.vim
+let s:plugin_root = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
+
+if filereadable('/rtp.vim')
+    source /rtp.vim
+endif
 
 " Load builtin plugins
 " We need this because run_vim.sh sets -i NONE
 if has('win32')
-    set runtimepath=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,C:\vader,C:\testplugin
+    execute 'set runtimepath=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,C:\vader,' . fnameescape(s:plugin_root)
 else
-    set runtimepath=/home/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,/testplugin,/vader
+    execute 'set runtimepath=/home/vim,$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after,' . fnameescape(s:plugin_root) . ',/vader'
 endif
 
 " The following is just an example

--- a/tests/vimrc
+++ b/tests/vimrc
@@ -2,6 +2,10 @@
 
 let s:plugin_root = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
 
+if exists('$PRETTIER_EXEC_CMD_PATH') && $PRETTIER_EXEC_CMD_PATH !=# ''
+    let g:prettier#exec_cmd_path = $PRETTIER_EXEC_CMD_PATH
+endif
+
 if filereadable('/rtp.vim')
     source /rtp.vim
 endif

--- a/tests/vimscript/version.vim
+++ b/tests/vimscript/version.vim
@@ -102,23 +102,23 @@ function! s:Run_tests() abort
           \ function('s:Test_is_greater_or_equal_version_lesser_case'),
           \ function('s:Test_is_greater_or_equal_version_equal_case')]
 
-  let l:results_as_returned = l:test_functions->copy()->map('v:val()')
-  let l:results_as_text = l:results_as_returned
-          \ ->copy()
-          \ ->map('v:key + 1 .. '': '' .. (v:val ? "failed" : "passed")')
+  let l:results_as_returned = map(copy(l:test_functions), 'v:val()')
+  let l:results_as_text = map(
+          \ copy(l:results_as_returned),
+          \ 'string(v:key + 1) . '': '' . (v:val ? ''failed'' : ''passed'')')
 
-  let l:has_failed_test = v:errors->len() > 0
-          \ || l:results_as_returned->index(1) >= 0
+  let l:has_failed_test = len(v:errors) > 0
+          \ || index(l:results_as_returned, 1) >= 0
   if l:has_failed_test
     echoerr 'The tests failed.'
     echoerr 'Results:'
-    echoerr l:results_as_text->join('; ')
+    echoerr join(l:results_as_text, '; ')
     echoerr 'Errors:'
-    echoerr v:errors->join('; ')
+    echoerr join(v:errors, '; ')
   else
     echomsg 'The tests were completed successfully.'
     echomsg 'Results:'
-    echomsg l:results_as_text->join('; ')
+    echomsg join(l:results_as_text, '; ')
   endif
 endfunction
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,12 +684,10 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
-  dependencies:
-    sprintf-js "~1.0.2"
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -764,10 +762,10 @@ baseline-browser-mapping@^2.10.12:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz#c84d093c4bf7325c5053c279d90f153c66526042"
   integrity sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@1.1.15, brace-expansion@^1.1.7:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
+  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -883,7 +881,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.3.0, colors@^1.3.2:
+colors@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -983,11 +981,6 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
-esprima@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 execa@^5.0.0:
   version "5.1.1"
@@ -1600,13 +1593,12 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+js-yaml@4.2.0, js-yaml@^3.13.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
+    argparse "^2.0.1"
 
 jsesc@^3.0.2:
   version "3.1.0"
@@ -1714,10 +1706,10 @@ mimic-fn@^3.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
-minimatch@^3.0.4, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@3.1.5, minimatch@^3.0.4, minimatch@^3.1.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -1725,11 +1717,6 @@ ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -1961,13 +1948,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shortid@^2.2.8:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
-  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
-  dependencies:
-    nanoid "^2.1.0"
-
 signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -1995,11 +1975,6 @@ source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 stack-utils@^2.0.3:
   version "2.0.6"
@@ -2118,14 +2093,6 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
-
-vim-driver@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vim-driver/-/vim-driver-1.0.1.tgz#3a95f6bc03dd29bc8a8cf9b232789bfa7773ac7f"
-  integrity sha512-OM0mHXqw/rV5A8vmiffktRYimDe5WlMcLxFWYNMlOtLRLioAVyFrnFfl5TNJeygMmbLmx7g/yY0PKRJ0Uz9snQ==
-  dependencies:
-    colors "^1.3.0"
-    shortid "^2.2.8"
 
 walker@^1.0.8:
   version "1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,27 +2,515 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0-beta.35":
-  version "7.22.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
-  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
   dependencies:
-    "@babel/highlight" "^7.22.13"
-    chalk "^2.4.2"
-
-"@babel/helper-validator-identifier@^7.22.20":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
-  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
-
-"@babel/highlight@^7.22.13":
-  version "7.22.20"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
-  integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.22.20"
-    chalk "^2.4.2"
+    "@babel/helper-validator-identifier" "^7.29.7"
     js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
+
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/generator@^7.29.7", "@babel/generator@^7.7.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
+  integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
+
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.29.7", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
+
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/plugin-syntax-async-generators@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
+  integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-bigint@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
+  integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-class-static-block@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz#195df89b146b4b78b3bf897fd7a257c84659d406"
+  integrity sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-import-attributes@^7.24.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz#6115264516e95ead0f35a41710906612e447f605"
+  integrity sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-import-meta@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz#ee601348c370fa334d2207be158777496521fd51"
+  integrity sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-json-strings@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
+  integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
+  integrity sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-numeric-separator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz#b9b070b3e33570cd9fd07ba7fa91c0dd37b9af97"
+  integrity sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-object-rest-spread@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
+  integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
+  integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-private-property-in-object@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad"
+  integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-top-level-await@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c"
+  integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/template@^7.29.7", "@babel/template@^7.3.3":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/traverse@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
+  integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    debug "^4.3.1"
+
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.28.2", "@babel/types@^7.29.7", "@babel/types@^7.3.3":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
+  integrity sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
+  dependencies:
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    get-package-type "^0.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
+
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
+"@jest/console@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"
+  integrity sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    slash "^3.0.0"
+
+"@jest/core@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.7.0.tgz#b6cccc239f30ff36609658c5a5e2291757ce448f"
+  integrity sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/reporters" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-changed-files "^29.7.0"
+    jest-config "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-resolve-dependencies "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    jest-watcher "^29.7.0"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    strip-ansi "^6.0.0"
+
+"@jest/environment@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
+  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
+  dependencies:
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
+  dependencies:
+    jest-get-type "^29.6.3"
+
+"@jest/expect@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.7.0.tgz#76a3edb0cb753b70dfbfe23283510d3d45432bf2"
+  integrity sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==
+  dependencies:
+    expect "^29.7.0"
+    jest-snapshot "^29.7.0"
+
+"@jest/fake-timers@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
+  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@types/node" "*"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
+
+"@jest/globals@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
+  integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    jest-mock "^29.7.0"
+
+"@jest/reporters@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.7.0.tgz#04b262ecb3b8faa83b0b3d321623972393e8f4c7"
+  integrity sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    collect-v8-coverage "^1.0.0"
+    exit "^0.1.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^6.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
+    slash "^3.0.0"
+    string-length "^4.0.1"
+    strip-ansi "^6.0.0"
+    v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
+"@jest/source-map@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.6.3.tgz#d90ba772095cf37a34a5eb9413f1b562a08554c4"
+  integrity sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.18"
+    callsites "^3.0.0"
+    graceful-fs "^4.2.9"
+
+"@jest/test-result@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.7.0.tgz#8db9a80aa1a097bb2262572686734baed9b1657c"
+  integrity sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/test-sequencer@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz#6cef977ce1d39834a3aea887a1726628a6f072ce"
+  integrity sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==
+  dependencies:
+    "@jest/test-result" "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    slash "^3.0.0"
+
+"@jest/transform@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.7.0.tgz#df2dd9c346c7d7768b8a06639994640c642e284c"
+  integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.2"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@prettier/plugin-lua@0.0.1":
   version "0.0.1"
@@ -55,6 +543,108 @@
     "@xml-tools/parser" "^1.0.2"
     prettier ">=1.10"
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.10"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
+  integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.0"
+
+"@types/babel__core@^7.1.14":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.27.0.tgz#b5819294c51179957afaec341442f9341e4108a9"
+  integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.4.tgz#5672513701c1b2199bc6dad636a9d7491586766f"
+  integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.28.0.tgz#07d713d6cce0d265c9849db0cbe62d3f61f36f74"
+  integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
+  dependencies:
+    "@babel/types" "^7.28.2"
+
+"@types/graceful-fs@^4.1.3":
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
+  integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz#53047614ae72e19fc0401d872de3ae2b4ce350bf"
+  integrity sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
+  integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/node@*":
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.0.0.tgz#d4aece9e9412e9f2008d59bc2d74f5279316b665"
+  integrity sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==
+  dependencies:
+    undici-types "~8.3.0"
+
+"@types/stack-utils@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
+  integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/yargs-parser@*":
+  version "21.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
+  integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^17.0.8":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@xml-tools/parser@^1.0.2":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@xml-tools/parser/-/parser-1.0.11.tgz#a118a14099ea5c3c537e4781fad2fc195b57f8ff"
@@ -62,85 +652,37 @@
   dependencies:
     chevrotain "7.1.1"
 
-abab@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
-  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
-
-acorn-globals@^4.1.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
-  integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
+ansi-escapes@^4.2.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
-    acorn "^6.0.1"
-    acorn-walk "^6.0.1"
+    type-fest "^0.21.3"
 
-acorn-walk@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
-  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-acorn@^5.5.3:
-  version "5.7.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
-  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
-
-acorn@^6.0.1:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
-  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
-
-ajv@^6.12.3:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
+    color-convert "^2.0.1"
 
-ansi-escapes@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
-  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
-ansi-regex@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
-  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==
-
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+anymatch@^3.0.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
-    color-convert "^1.9.0"
-
-anymatch@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
-  integrity sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
-  dependencies:
-    micromatch "^3.1.4"
-    normalize-path "^2.1.1"
-
-append-transform@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
-  integrity sha512-Yisb7ew0ZEyDtRYQ+b+26o9KbiYPFxwcsxKzbssigzRRMJ9LpExPVUg6Fos7eP7yP3q7///tzze4nm4lTptPBw==
-  dependencies:
-    default-require-extensions "^1.0.0"
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -149,331 +691,78 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-arr-diff@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
-  integrity sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==
+babel-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
+  integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
   dependencies:
-    arr-flatten "^1.0.1"
+    "@jest/transform" "^29.7.0"
+    "@types/babel__core" "^7.1.14"
+    babel-plugin-istanbul "^6.1.1"
+    babel-preset-jest "^29.6.3"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    slash "^3.0.0"
 
-arr-diff@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
-  integrity sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==
-
-arr-flatten@^1.0.1, arr-flatten@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
-  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
-
-arr-union@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
-  integrity sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==
-
-array-buffer-byte-length@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
-  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+babel-plugin-istanbul@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
+  integrity sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==
   dependencies:
-    call-bind "^1.0.2"
-    is-array-buffer "^3.0.1"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^5.0.4"
+    test-exclude "^6.0.0"
 
-array-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
-  integrity sha512-H3LU5RLiSsGXPhN+Nipar0iR0IofH+8r89G2y1tBKxQ/agagKyAjhkAFDRBfodP2caPrNKHpAWNIM/c9yeL7uA==
-
-array-unique@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
-  integrity sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==
-
-array-unique@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
-  integrity sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==
-
-array.prototype.reduce@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/array.prototype.reduce/-/array.prototype.reduce-1.0.6.tgz#63149931808c5fc1e1354814923d92d45f7d96d5"
-  integrity sha512-UW+Mz8LG/sPSU8jRDCjVr6J/ZKAGpHfwrZ6kWTG5qCxIEiXdVshqGnu5vEZA8S1y6X4aCSbQZ0/EEsfvEvBiSg==
+babel-plugin-jest-hoist@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz#aadbe943464182a8922c3c927c3067ff40d24626"
+  integrity sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==
   dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    es-array-method-boxes-properly "^1.0.0"
-    is-string "^1.0.7"
+    "@babel/template" "^7.3.3"
+    "@babel/types" "^7.3.3"
+    "@types/babel__core" "^7.1.14"
+    "@types/babel__traverse" "^7.0.6"
 
-arraybuffer.prototype.slice@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz#98bd561953e3e74bb34938e77647179dfe6e9f12"
-  integrity sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==
+babel-preset-current-node-syntax@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz#20730d6cdc7dda5d89401cab10ac6a32067acde6"
+  integrity sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==
   dependencies:
-    array-buffer-byte-length "^1.0.0"
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    get-intrinsic "^1.2.1"
-    is-array-buffer "^3.0.2"
-    is-shared-array-buffer "^1.0.2"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-import-attributes" "^7.24.7"
+    "@babel/plugin-syntax-import-meta" "^7.10.4"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
 
-arrify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
-
-asn1@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
-  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+babel-preset-jest@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz#fa05fa510e7d493896d7b0dd2033601c840f171c"
+  integrity sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==
   dependencies:
-    safer-buffer "~2.1.0"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
-
-assign-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
-  integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
-
-astral-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
-  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
-
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async@^2.1.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
-  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
-  dependencies:
-    lodash "^4.17.14"
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
-atob@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
-  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
-
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
-
-aws4@^1.8.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
-  integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
-
-babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
-
-babel-core@^6.0.0, babel-core@^6.26.0:
-  version "6.26.3"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
-  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.1"
-    debug "^2.6.9"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.8"
-    slash "^1.0.0"
-    source-map "^0.5.7"
-
-babel-generator@^6.18.0, babel-generator@^6.26.0:
-  version "6.26.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
-  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.17.4"
-    source-map "^0.5.7"
-    trim-right "^1.0.1"
-
-babel-helpers@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
-  integrity sha512-n7pFrqQm44TCYvrCDb0MqabAF+JUBq+ijBvNMUxpkLjJaAu32faIexewMumrH5KLLJ1HDyT0PTEqRyAe/GwwuQ==
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-jest@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
-  integrity sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==
-  dependencies:
-    babel-plugin-istanbul "^4.1.6"
-    babel-preset-jest "^23.2.0"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  integrity sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-plugin-istanbul@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
-  integrity sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==
-  dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
-    find-up "^2.1.0"
-    istanbul-lib-instrument "^1.10.1"
-    test-exclude "^4.2.1"
-
-babel-plugin-jest-hoist@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
-  integrity sha512-N0MlMjZtahXK0yb0K3V9hWPrq5e7tThbghvDr0k3X75UuOOqwsWW6mk8XHD2QvEC0Ca9dLIfTgNU36TeJD6Hnw==
-
-babel-plugin-syntax-object-rest-spread@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
-  integrity sha512-C4Aq+GaAj83pRQ0EFgTvw5YO6T3Qz2KGrNRwIj9mSoNHVvdZY4KO2uA6HNtNXCw993iSZnckY1aLW8nOi8i4+w==
-
-babel-preset-jest@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
-  integrity sha512-AdfWwc0PYvDtwr009yyVNh72Ev68os7SsPmOFVX7zSA+STXuk5CV2iMVazZU01bEoHCSwTkgv4E4HOOcODPkPg==
-  dependencies:
-    babel-plugin-jest-hoist "^23.2.0"
-    babel-plugin-syntax-object-rest-spread "^6.13.0"
-
-babel-register@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
-  integrity sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==
-  dependencies:
-    babel-core "^6.26.0"
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.15"
-
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  integrity sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  integrity sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
+    babel-plugin-jest-hoist "^29.6.3"
+    babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base@^0.11.1:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
-  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
-  dependencies:
-    cache-base "^1.0.1"
-    class-utils "^0.3.5"
-    component-emitter "^1.2.1"
-    define-property "^1.0.0"
-    isobject "^3.0.1"
-    mixin-deep "^1.2.0"
-    pascalcase "^0.1.1"
-
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
-  dependencies:
-    tweetnacl "^0.14.3"
-
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
+baseline-browser-mapping@^2.10.12:
+  version "2.10.38"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz#c84d093c4bf7325c5053c279d90f153c66526042"
+  integrity sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -483,42 +772,23 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^1.8.2:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
-  integrity sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
-    expand-range "^1.8.1"
-    preserve "^0.2.0"
-    repeat-element "^1.1.2"
+    fill-range "^7.1.1"
 
-braces@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
-  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+browserslist@^4.24.0:
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
   dependencies:
-    arr-flatten "^1.1.0"
-    array-unique "^0.3.2"
-    extend-shallow "^2.0.1"
-    fill-range "^4.0.0"
-    isobject "^3.0.1"
-    repeat-element "^1.1.2"
-    snapdragon "^0.8.1"
-    snapdragon-node "^2.0.1"
-    split-string "^3.0.2"
-    to-regex "^3.0.1"
-
-browser-process-hrtime@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
-  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-
-browser-resolve@^1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
-  integrity sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==
-  dependencies:
-    resolve "1.1.7"
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
 
 bser@2.1.1:
   version "2.1.1"
@@ -532,70 +802,38 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-cache-base@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
-  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
-  dependencies:
-    collection-visit "^1.0.0"
-    component-emitter "^1.2.1"
-    get-value "^2.0.6"
-    has-value "^1.0.0"
-    isobject "^3.0.1"
-    set-value "^2.0.0"
-    to-object-path "^0.3.0"
-    union-value "^1.0.0"
-    unset-value "^1.0.0"
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-call-bind@^1.0.0, call-bind@^1.0.2:
+camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelcase@^6.2.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001799"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
+  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+char-regex@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
-  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
-  dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
-
-callsites@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
-  integrity sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==
-
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-  integrity sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==
-
-capture-exit@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"
-  integrity sha512-IS4lTgp57lUcpXzyCaiUQcRZBxZAkzl+jNXrMUXZjdnr2yujpKUMG9OYeYL29i6fL66ihypvVJ/MeX0B+9pWOg==
-  dependencies:
-    rsvp "^3.3.3"
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.0.1, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 chevrotain@7.1.1:
   version "7.1.1"
@@ -604,507 +842,188 @@ chevrotain@7.1.1:
   dependencies:
     regexp-to-ast "0.5.0"
 
-ci-info@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
-  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
-class-utils@^0.3.5:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
-  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  dependencies:
-    arr-union "^3.1.0"
-    define-property "^0.2.5"
-    isobject "^3.0.0"
-    static-extend "^0.1.1"
+cjs-module-lexer@^1.0.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz#0f79731eb8cfe1ec72acd4066efac9d61991b00d"
+  integrity sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==
 
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
   dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
 
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
+collect-v8-coverage@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz#cc1f01eb8d02298cbc9a437c74c70ab4e5210b80"
+  integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
 
-collection-visit@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
-  integrity sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
-    map-visit "^1.0.0"
-    object-visit "^1.0.0"
+    color-name "~1.1.4"
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 colors@^1.3.0, colors@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
-component-emitter@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-convert-source-map@^1.4.0, convert-source-map@^1.5.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-copy-descriptor@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-  integrity sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==
-
-core-js@^2.4.0, core-js@^2.5.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
-
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
-cross-spawn@^6.0.0:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
-  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+create-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
+  integrity sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==
   dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    prompts "^2.0.1"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
-  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
-
-cssstyle@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.4.0.tgz#9d31328229d3c565c61e586b02041a28fccdccf1"
-  integrity sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==
+cross-spawn@^7.0.3:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
-    cssom "0.3.x"
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
-    assert-plus "^1.0.0"
+    ms "^2.1.3"
 
-data-urls@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
-  integrity sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
-  dependencies:
-    abab "^2.0.0"
-    whatwg-mimetype "^2.2.0"
-    whatwg-url "^7.0.0"
+dedent@^1.0.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
-debug@^3.1.0:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-decamelize@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
-decode-uri-component@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+electron-to-chromium@^1.5.328:
+  version "1.5.376"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz#16a9d4b72cb16c416aa73a879d92b047b96797ac"
+  integrity sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==
 
-deep-is@~0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
-  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
-default-require-extensions@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
-  integrity sha512-Dn2eAftOqXhNXs5f/Xjn7QTZ6kDYkx7u0EXQInN1oyYwsZysu11q7oTtaKcbzLxZRJiDHa8VmwpWmb4lY5FqgA==
-  dependencies:
-    strip-bom "^2.0.0"
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-define-data-property@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.0.tgz#0db13540704e1d8d479a0656cf781267531b9451"
-  integrity sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==
-  dependencies:
-    get-intrinsic "^1.2.1"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
-
-define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
-  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
-  dependencies:
-    define-data-property "^1.0.1"
-    has-property-descriptors "^1.0.0"
-    object-keys "^1.1.1"
-
-define-property@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
-  integrity sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==
-  dependencies:
-    is-descriptor "^0.1.0"
-
-define-property@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
-  integrity sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==
-  dependencies:
-    is-descriptor "^1.0.0"
-
-define-property@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
-  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
-  dependencies:
-    is-descriptor "^1.0.2"
-    isobject "^3.0.1"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
-detect-indent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
-  integrity sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==
-  dependencies:
-    repeating "^2.0.0"
-
-detect-newline@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
-  integrity sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==
-
-diff@^3.2.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
-domexception@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
-  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
-  dependencies:
-    webidl-conversions "^4.0.2"
-
-ecc-jsbn@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
-  dependencies:
-    jsbn "~0.1.0"
-    safer-buffer "^2.1.0"
-
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
-
-error-ex@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
-  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+error-ex@^1.3.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.4.tgz#b3a8d8bb6f92eecc1629e3e27d3c8607a8a32414"
+  integrity sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.22.1:
-  version "1.22.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.2.tgz#90f7282d91d0ad577f505e423e52d4c1d93c1b8a"
-  integrity sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==
-  dependencies:
-    array-buffer-byte-length "^1.0.0"
-    arraybuffer.prototype.slice "^1.0.2"
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    es-set-tostringtag "^2.0.1"
-    es-to-primitive "^1.2.1"
-    function.prototype.name "^1.1.6"
-    get-intrinsic "^1.2.1"
-    get-symbol-description "^1.0.0"
-    globalthis "^1.0.3"
-    gopd "^1.0.1"
-    has "^1.0.3"
-    has-property-descriptors "^1.0.0"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
-    internal-slot "^1.0.5"
-    is-array-buffer "^3.0.2"
-    is-callable "^1.2.7"
-    is-negative-zero "^2.0.2"
-    is-regex "^1.1.4"
-    is-shared-array-buffer "^1.0.2"
-    is-string "^1.0.7"
-    is-typed-array "^1.1.12"
-    is-weakref "^1.0.2"
-    object-inspect "^1.12.3"
-    object-keys "^1.1.1"
-    object.assign "^4.1.4"
-    regexp.prototype.flags "^1.5.1"
-    safe-array-concat "^1.0.1"
-    safe-regex-test "^1.0.0"
-    string.prototype.trim "^1.2.8"
-    string.prototype.trimend "^1.0.7"
-    string.prototype.trimstart "^1.0.7"
-    typed-array-buffer "^1.0.0"
-    typed-array-byte-length "^1.0.0"
-    typed-array-byte-offset "^1.0.0"
-    typed-array-length "^1.0.4"
-    unbox-primitive "^1.0.2"
-    which-typed-array "^1.1.11"
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
-es-array-method-boxes-properly@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
-  integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
-
-es-set-tostringtag@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
-  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
-  dependencies:
-    get-intrinsic "^1.1.3"
-    has "^1.0.3"
-    has-tostringtag "^1.0.0"
-
-es-to-primitive@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
-  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
-  dependencies:
-    is-callable "^1.1.4"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.2"
-
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+escalade@^3.1.1, escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escodegen@^1.9.1:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
-  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
-
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-estraverse@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-exec-sh@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
-  integrity sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==
+execa@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
   dependencies:
-    merge "^1.2.0"
-
-execa@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
-  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
-  dependencies:
-    cross-spawn "^6.0.0"
-    get-stream "^4.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
 
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expand-brackets@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
-  integrity sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==
+expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
   dependencies:
-    is-posix-bracket "^0.1.0"
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
 
-expand-brackets@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
-  integrity sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==
-  dependencies:
-    debug "^2.3.3"
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    posix-character-classes "^0.1.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
-
-expand-range@^1.8.1:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
-  integrity sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==
-  dependencies:
-    fill-range "^2.1.0"
-
-expect@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.6.0.tgz#1e0c8d3ba9a581c87bd71fb9bc8862d443425f98"
-  integrity sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==
-  dependencies:
-    ansi-styles "^3.2.0"
-    jest-diff "^23.6.0"
-    jest-get-type "^22.1.0"
-    jest-matcher-utils "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
-
-extend-shallow@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-  integrity sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==
-  dependencies:
-    is-extendable "^0.1.0"
-
-extend-shallow@^3.0.0, extend-shallow@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
-  integrity sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==
-  dependencies:
-    assign-symbols "^1.0.0"
-    is-extendable "^1.0.1"
-
-extend@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-extglob@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
-  integrity sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==
-  dependencies:
-    is-extglob "^1.0.0"
-
-extglob@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
-  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
-  dependencies:
-    array-unique "^0.3.2"
-    define-property "^1.0.0"
-    expand-brackets "^2.1.4"
-    extend-shallow "^2.0.1"
-    fragment-cache "^0.2.1"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
-
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
-fast-deep-equal@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
-  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
-
-fast-levenshtein@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -1113,191 +1032,57 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
-filename-regex@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
-  integrity sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==
-
-fileset@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/fileset/-/fileset-2.0.3.tgz#8e7548a96d3cc2327ee5e674168723a333bba2a0"
-  integrity sha512-UxowFKnAFIwtmSxgKjWAVgjE3Fk7MQJT0ZIyl0NwIFZTrx4913rLaonGJ84V+x/2+w/pe4ULHRns+GZPs1TVuw==
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
-    glob "^7.0.3"
-    minimatch "^3.0.3"
+    to-regex-range "^5.0.1"
 
-fill-range@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.4.tgz#eb1e773abb056dcd8df2bfdf6af59b8b3a936565"
-  integrity sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==
+find-up@^4.0.0, find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
   dependencies:
-    is-number "^2.1.0"
-    isobject "^2.0.0"
-    randomatic "^3.0.0"
-    repeat-element "^1.1.2"
-    repeat-string "^1.5.2"
-
-fill-range@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
-  integrity sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-number "^3.0.0"
-    repeat-string "^1.6.1"
-    to-regex-range "^2.1.0"
-
-find-up@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
-  integrity sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==
-  dependencies:
-    path-exists "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-find-up@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
-  integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
-  dependencies:
-    locate-path "^2.0.0"
-
-for-each@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
-  dependencies:
-    is-callable "^1.1.3"
-
-for-in@^1.0.1, for-in@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
-  integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
-
-for-own@^0.1.4:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
-  integrity sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==
-  dependencies:
-    for-in "^1.0.1"
-
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
-fragment-cache@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
-  integrity sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==
-  dependencies:
-    map-cache "^0.2.2"
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^1.2.3:
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
-  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.12.1"
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-function.prototype.name@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.6.tgz#cdf315b7d90ee77a4c6ee216c3c3362da07533fd"
-  integrity sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    functions-have-names "^1.2.3"
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-functions-have-names@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
-  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-caller-file@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
-  integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
+get-package-type@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
+  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
-  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
-  dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-get-stream@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
-  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
-  dependencies:
-    pump "^3.0.0"
-
-get-symbol-description@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
-  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.1"
-
-get-value@^2.0.3, get-value@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
-  integrity sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==
-
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
-  dependencies:
-    assert-plus "^1.0.0"
-
-glob-base@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
-  integrity sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==
-  dependencies:
-    glob-parent "^2.0.0"
-    is-glob "^2.0.0"
-
-glob-parent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
-  integrity sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==
-  dependencies:
-    is-glob "^2.0.0"
-
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -1309,185 +1094,40 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
-
-globalthis@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
-  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
-  dependencies:
-    define-properties "^1.1.3"
-
-gopd@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
-  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
-  dependencies:
-    get-intrinsic "^1.1.3"
-
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
-growly@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-  integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-handlebars@^4.0.3:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+hasown@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
-    minimist "^1.2.5"
-    neo-async "^2.6.2"
-    source-map "^0.6.1"
-    wordwrap "^1.0.0"
-  optionalDependencies:
-    uglify-js "^3.1.4"
+    function-bind "^1.1.2"
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+import-local@^3.0.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.2.0.tgz#c3d5c745798c02a6f8b897726aba5100186ee260"
+  integrity sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==
   dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==
-  dependencies:
-    ansi-regex "^2.0.0"
-
-has-bigints@^1.0.1, has-bigints@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
-  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
-
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
-
-has-property-descriptors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
-  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
-  dependencies:
-    get-intrinsic "^1.1.1"
-
-has-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
-  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
-
-has-symbols@^1.0.2, has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
-has-tostringtag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
-  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
-  dependencies:
-    has-symbols "^1.0.2"
-
-has-value@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
-  integrity sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==
-  dependencies:
-    get-value "^2.0.3"
-    has-values "^0.1.4"
-    isobject "^2.0.0"
-
-has-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
-  integrity sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==
-  dependencies:
-    get-value "^2.0.6"
-    has-values "^1.0.0"
-    isobject "^3.0.0"
-
-has-values@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
-  integrity sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==
-
-has-values@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
-  integrity sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==
-  dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
-
-has@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
-  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
-
-home-or-tmp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
-  integrity sha512-ycURW7oUxE2sNiPVw1HVEFsW+ecOpJ5zaj7eC0RlwhibhRBod20muUN8qu/gzx956YrLolVvs1MTXwKgC2rVEg==
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.1"
-
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
-
-html-encoding-sniffer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
-  integrity sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==
-  dependencies:
-    whatwg-encoding "^1.0.1"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
-iconv-lite@0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
-
-import-local@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
-  integrity sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==
-  dependencies:
-    pkg-dir "^2.0.0"
-    resolve-cwd "^2.0.0"
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -1502,920 +1142,532 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-internal-slot@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
-  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
-  dependencies:
-    get-intrinsic "^1.2.0"
-    has "^1.0.3"
-    side-channel "^1.0.4"
-
-invariant@^2.2.2, invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
-
-invert-kv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
-  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
-
-is-accessor-descriptor@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
-  integrity sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==
-  dependencies:
-    kind-of "^3.0.2"
-
-is-accessor-descriptor@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
-  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
-  dependencies:
-    kind-of "^6.0.0"
-
-is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
-  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.2.0"
-    is-typed-array "^1.1.10"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
-is-bigint@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
-  integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
+is-core-module@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
   dependencies:
-    has-bigints "^1.0.1"
+    hasown "^2.0.3"
 
-is-boolean-object@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
-  integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
-is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
-  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
-
-is-ci@^1.0.10:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
-  integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
-  dependencies:
-    ci-info "^1.5.0"
-
-is-core-module@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
-  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
-  dependencies:
-    has "^1.0.3"
-
-is-data-descriptor@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
-  integrity sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==
-  dependencies:
-    kind-of "^3.0.2"
-
-is-data-descriptor@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
-  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
-  dependencies:
-    kind-of "^6.0.0"
-
-is-date-object@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
-  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
-is-descriptor@^0.1.0:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
-  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
-  dependencies:
-    is-accessor-descriptor "^0.1.6"
-    is-data-descriptor "^0.1.4"
-    kind-of "^5.0.0"
-
-is-descriptor@^1.0.0, is-descriptor@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
-  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
-  dependencies:
-    is-accessor-descriptor "^1.0.0"
-    is-data-descriptor "^1.0.0"
-    kind-of "^6.0.2"
-
-is-dotfile@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
-  integrity sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==
-
-is-equal-shallow@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
-  integrity sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==
-  dependencies:
-    is-primitive "^2.0.0"
-
-is-extendable@^0.1.0, is-extendable@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
-  integrity sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==
-
-is-extendable@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
-  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
-  dependencies:
-    is-plain-object "^2.0.4"
-
-is-extglob@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
-  integrity sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==
-
-is-finite@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.1.0.tgz#904135c77fb42c0641d6aa1bcdbc4daa8da082f3"
-  integrity sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==
-
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==
-  dependencies:
-    number-is-nan "^1.0.0"
-
-is-fullwidth-code-point@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
-
-is-generator-fn@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
-  integrity sha512-95jJZX6O/gdekidH2usRBr9WdRw4LU56CttPstXFxvG0r3QUE9eaIdz2p2Y7zrm6jxz7SjByAo1AtzwGlRvfOg==
-
-is-glob@^2.0.0, is-glob@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
-  integrity sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==
-  dependencies:
-    is-extglob "^1.0.0"
-
-is-negative-zero@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
-  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
-
-is-number-object@^1.0.4:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
-  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
-is-number@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
-  integrity sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==
-  dependencies:
-    kind-of "^3.0.2"
-
-is-number@^3.0.0:
+is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
-  integrity sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==
-  dependencies:
-    kind-of "^3.0.2"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-number@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
-  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
+is-generator-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-plain-object@^2.0.3, is-plain-object@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
-  dependencies:
-    isobject "^3.0.1"
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-posix-bracket@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
-  integrity sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==
-
-is-primitive@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-  integrity sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==
-
-is-regex@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
-  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
-is-shared-array-buffer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
-  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
-  dependencies:
-    call-bind "^1.0.2"
-
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
-
-is-string@^1.0.5, is-string@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
-  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
-is-symbol@^1.0.2, is-symbol@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
-  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
-  dependencies:
-    has-symbols "^1.0.2"
-
-is-typed-array@^1.1.10, is-typed-array@^1.1.12, is-typed-array@^1.1.9:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
-  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
-  dependencies:
-    which-typed-array "^1.1.11"
-
-is-typedarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
-
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-  integrity sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==
-
-is-weakref@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
-  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
-  dependencies:
-    call-bind "^1.0.2"
-
-is-windows@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
-  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
-
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==
-
-isarray@1.0.0, isarray@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
-
-isarray@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
-  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-isobject@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
-  integrity sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==
-  dependencies:
-    isarray "1.0.0"
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
 
-isobject@^3.0.0, isobject@^3.0.1:
+istanbul-lib-instrument@^5.0.4:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz#d10c8885c2125574e1c231cacadf955675e1ce3d"
+  integrity sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==
+  dependencies:
+    "@babel/core" "^7.12.3"
+    "@babel/parser" "^7.14.7"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^6.3.0"
+
+istanbul-lib-instrument@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
+istanbul-lib-report@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
-
-istanbul-api@^1.3.1:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.7.tgz#a86c770d2b03e11e3f778cd7aedd82d2722092aa"
-  integrity sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
   dependencies:
-    async "^2.1.4"
-    fileset "^2.0.2"
-    istanbul-lib-coverage "^1.2.1"
-    istanbul-lib-hook "^1.2.2"
-    istanbul-lib-instrument "^1.10.2"
-    istanbul-lib-report "^1.1.5"
-    istanbul-lib-source-maps "^1.2.6"
-    istanbul-reports "^1.5.1"
-    js-yaml "^3.7.0"
-    mkdirp "^0.5.1"
-    once "^1.4.0"
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
 
-istanbul-lib-coverage@^1.2.0, istanbul-lib-coverage@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
-  integrity sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==
-
-istanbul-lib-hook@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz#bc6bf07f12a641fbf1c85391d0daa8f0aea6bf86"
-  integrity sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz#895f3a709fcfba34c6de5a42939022f3e4358551"
+  integrity sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==
   dependencies:
-    append-transform "^0.4.0"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
 
-istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz#1f55ed10ac3c47f2bdddd5307935126754d0a9ca"
-  integrity sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==
+istanbul-reports@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
   dependencies:
-    babel-generator "^6.18.0"
-    babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
-    babylon "^6.18.0"
-    istanbul-lib-coverage "^1.2.1"
-    semver "^5.3.0"
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
-istanbul-lib-report@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz#f2a657fc6282f96170aaf281eb30a458f7f4170c"
-  integrity sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==
+jest-changed-files@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
+  integrity sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==
   dependencies:
-    istanbul-lib-coverage "^1.2.1"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
+    execa "^5.0.0"
+    jest-util "^29.7.0"
+    p-limit "^3.1.0"
 
-istanbul-lib-source-maps@^1.2.4, istanbul-lib-source-maps@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz#37b9ff661580f8fca11232752ee42e08c6675d8f"
-  integrity sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==
+jest-circus@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.7.0.tgz#b6817a45fcc835d8b16d5962d0c026473ee3668a"
+  integrity sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==
   dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.2.1"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
-
-istanbul-reports@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.5.1.tgz#97e4dbf3b515e8c484caea15d6524eebd3ff4e1a"
-  integrity sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==
-  dependencies:
-    handlebars "^4.0.3"
-
-jest-changed-files@^23.4.2:
-  version "23.4.2"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
-  integrity sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==
-  dependencies:
-    throat "^4.0.0"
-
-jest-cli@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.6.0.tgz#61ab917744338f443ef2baa282ddffdd658a5da4"
-  integrity sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    exit "^0.1.2"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    import-local "^1.0.0"
-    is-ci "^1.0.10"
-    istanbul-api "^1.3.1"
-    istanbul-lib-coverage "^1.2.0"
-    istanbul-lib-instrument "^1.10.1"
-    istanbul-lib-source-maps "^1.2.4"
-    jest-changed-files "^23.4.2"
-    jest-config "^23.6.0"
-    jest-environment-jsdom "^23.4.0"
-    jest-get-type "^22.1.0"
-    jest-haste-map "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
-    jest-resolve-dependencies "^23.6.0"
-    jest-runner "^23.6.0"
-    jest-runtime "^23.6.0"
-    jest-snapshot "^23.6.0"
-    jest-util "^23.4.0"
-    jest-validate "^23.6.0"
-    jest-watcher "^23.4.0"
-    jest-worker "^23.2.0"
-    micromatch "^2.3.11"
-    node-notifier "^5.2.1"
-    prompts "^0.1.9"
-    realpath-native "^1.0.0"
-    rimraf "^2.5.4"
-    slash "^1.0.0"
-    string-length "^2.0.0"
-    strip-ansi "^4.0.0"
-    which "^1.2.12"
-    yargs "^11.0.0"
-
-jest-config@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.6.0.tgz#f82546a90ade2d8c7026fbf6ac5207fc22f8eb1d"
-  integrity sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==
-  dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^23.6.0"
-    chalk "^2.0.1"
-    glob "^7.1.1"
-    jest-environment-jsdom "^23.4.0"
-    jest-environment-node "^23.4.0"
-    jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.6.0"
-    jest-regex-util "^23.3.0"
-    jest-resolve "^23.6.0"
-    jest-util "^23.4.0"
-    jest-validate "^23.6.0"
-    micromatch "^2.3.11"
-    pretty-format "^23.6.0"
-
-jest-diff@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.6.0.tgz#1500f3f16e850bb3d71233408089be099f610c7d"
-  integrity sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==
-  dependencies:
-    chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.6.0"
-
-jest-docblock@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
-  integrity sha512-CB8MdScYLkzQ0Q/I4FYlt2UBkG9tFzi+ngSPVhSBB70nifaC+5iWz6GEfa/lB4T2KCqGy+DLzi1v34r9R1XzuA==
-  dependencies:
-    detect-newline "^2.1.0"
-
-jest-each@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.6.0.tgz#ba0c3a82a8054387016139c733a05242d3d71575"
-  integrity sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==
-  dependencies:
-    chalk "^2.0.1"
-    pretty-format "^23.6.0"
-
-jest-environment-jsdom@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
-  integrity sha512-UIXe32cMl/+DtyNHC15X+aFZMh04wx7PjWFBfz+nwoLgsIN2loKoNiKGSzUhMW/fVwbHrk8Qopglb7V4XB4EfQ==
-  dependencies:
-    jest-mock "^23.2.0"
-    jest-util "^23.4.0"
-    jsdom "^11.5.1"
-
-jest-environment-node@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
-  integrity sha512-bk8qScgIfkb+EdwJ0JZ9xGvN7N3m6Qok73G8hi6tzvNadpe4kOxxuGmK2cJzAM3tPC/HBulzrOeNHEvaThQFrQ==
-  dependencies:
-    jest-mock "^23.2.0"
-    jest-util "^23.4.0"
-
-jest-get-type@^22.1.0:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
-  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
-
-jest-haste-map@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.6.0.tgz#2e3eb997814ca696d62afdb3f2529f5bbc935e16"
-  integrity sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    invariant "^2.2.4"
-    jest-docblock "^23.2.0"
-    jest-serializer "^23.0.1"
-    jest-worker "^23.2.0"
-    micromatch "^2.3.11"
-    sane "^2.0.0"
-
-jest-jasmine2@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz#840e937f848a6c8638df24360ab869cc718592e0"
-  integrity sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==
-  dependencies:
-    babel-traverse "^6.0.0"
-    chalk "^2.0.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
     co "^4.6.0"
-    expect "^23.6.0"
-    is-generator-fn "^1.0.0"
-    jest-diff "^23.6.0"
-    jest-each "^23.6.0"
-    jest-matcher-utils "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-snapshot "^23.6.0"
-    jest-util "^23.4.0"
-    pretty-format "^23.6.0"
+    dedent "^1.0.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^29.7.0"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    p-limit "^3.1.0"
+    pretty-format "^29.7.0"
+    pure-rand "^6.0.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
 
-jest-leak-detector@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz#e4230fd42cf381a1a1971237ad56897de7e171de"
-  integrity sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==
+jest-cli@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.7.0.tgz#5592c940798e0cae677eec169264f2d839a37995"
+  integrity sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==
   dependencies:
-    pretty-format "^23.6.0"
-
-jest-matcher-utils@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#726bcea0c5294261a7417afb6da3186b4b8cac80"
-  integrity sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==
-  dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    pretty-format "^23.6.0"
-
-jest-message-util@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
-  integrity sha512-Tjqy7T8jHhPgV4Gsi+pKMMfaz3uP5DPtMGnm8RWNWUHIk2igqxQ3/9rud3JkINCvZDGqlpJVuFGIDXbltG4xLA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0-beta.35"
-    chalk "^2.0.1"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
-    stack-utils "^1.0.1"
-
-jest-mock@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
-  integrity sha512-lz+Rf6dwRNDVowuGCXm93ib8hMyPntl1GGVt9PuZfBAmTjP5yKYgK14IASiEjs7XoMo4i/R7+dkrJY3eESwTJg==
-
-jest-regex-util@^23.3.0:
-  version "23.3.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
-  integrity sha512-pNilf1tXhv5z0qjJy2Hl6Ar6dsi+XX2zpCAuzxRs4qoputI0Bm9rU7pa2ErrFTfiHYe8VboTR7WATPZXqzpQ/g==
-
-jest-resolve-dependencies@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz#b4526af24c8540d9a3fab102c15081cf509b723d"
-  integrity sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==
-  dependencies:
-    jest-regex-util "^23.3.0"
-    jest-snapshot "^23.6.0"
-
-jest-resolve@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.6.0.tgz#cf1d1a24ce7ee7b23d661c33ba2150f3aebfa0ae"
-  integrity sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==
-  dependencies:
-    browser-resolve "^1.11.3"
-    chalk "^2.0.1"
-    realpath-native "^1.0.0"
-
-jest-runner@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.6.0.tgz#3894bd219ffc3f3cb94dc48a4170a2e6f23a5a38"
-  integrity sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==
-  dependencies:
+    "@jest/core" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    create-jest "^29.7.0"
     exit "^0.1.2"
-    graceful-fs "^4.1.11"
-    jest-config "^23.6.0"
-    jest-docblock "^23.2.0"
-    jest-haste-map "^23.6.0"
-    jest-jasmine2 "^23.6.0"
-    jest-leak-detector "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-runtime "^23.6.0"
-    jest-util "^23.4.0"
-    jest-worker "^23.2.0"
-    source-map-support "^0.5.6"
-    throat "^4.0.0"
+    import-local "^3.0.2"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    yargs "^17.3.1"
 
-jest-runtime@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.6.0.tgz#059e58c8ab445917cd0e0d84ac2ba68de8f23082"
-  integrity sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==
+jest-config@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.7.0.tgz#bcbda8806dbcc01b1e316a46bb74085a84b0245f"
+  integrity sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==
   dependencies:
-    babel-core "^6.0.0"
-    babel-plugin-istanbul "^4.1.6"
-    chalk "^2.0.1"
-    convert-source-map "^1.4.0"
-    exit "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-config "^23.6.0"
-    jest-haste-map "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-regex-util "^23.3.0"
-    jest-resolve "^23.6.0"
-    jest-snapshot "^23.6.0"
-    jest-util "^23.4.0"
-    jest-validate "^23.6.0"
-    micromatch "^2.3.11"
-    realpath-native "^1.0.0"
-    slash "^1.0.0"
-    strip-bom "3.0.0"
-    write-file-atomic "^2.1.0"
-    yargs "^11.0.0"
+    "@babel/core" "^7.11.6"
+    "@jest/test-sequencer" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-jest "^29.7.0"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    deepmerge "^4.2.2"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-circus "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    micromatch "^4.0.4"
+    parse-json "^5.2.0"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
 
-jest-serializer@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
-  integrity sha512-l6cPuiGEQI72H4+qMePF62E+URkZscnAqdHBYHkMrhKJOwU08AHvGmftXdosUzfCGhh/Ih4Xk1VgxnJSwrvQvQ==
-
-jest-snapshot@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.6.0.tgz#f9c2625d1b18acda01ec2d2b826c0ce58a5aa17a"
-  integrity sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
   dependencies:
-    babel-types "^6.0.0"
-    chalk "^2.0.1"
-    jest-diff "^23.6.0"
-    jest-matcher-utils "^23.6.0"
-    jest-message-util "^23.4.0"
-    jest-resolve "^23.6.0"
-    mkdirp "^0.5.1"
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-docblock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
+  integrity sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==
+  dependencies:
+    detect-newline "^3.0.0"
+
+jest-each@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.7.0.tgz#162a9b3f2328bdd991beaabffbb74745e56577d1"
+  integrity sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    jest-get-type "^29.6.3"
+    jest-util "^29.7.0"
+    pretty-format "^29.7.0"
+
+jest-environment-node@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.7.0.tgz#0b93e111dda8ec120bc8300e6d1fb9576e164376"
+  integrity sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
+
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
+jest-haste-map@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.7.0.tgz#3c2396524482f5a0506376e6c858c3bbcc17b104"
+  integrity sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
+jest-leak-detector@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
+  integrity sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==
+  dependencies:
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-mock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
+  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-util "^29.7.0"
+
+jest-pnp-resolver@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz#930b1546164d4ad5937d5540e711d4d38d4cad2e"
+  integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
+
+jest-regex-util@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
+  integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
+
+jest-resolve-dependencies@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz#1b04f2c095f37fc776ff40803dc92921b1e88428"
+  integrity sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==
+  dependencies:
+    jest-regex-util "^29.6.3"
+    jest-snapshot "^29.7.0"
+
+jest-resolve@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.7.0.tgz#64d6a8992dd26f635ab0c01e5eef4399c6bcbc30"
+  integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
+  dependencies:
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-pnp-resolver "^1.2.2"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    resolve "^1.20.0"
+    resolve.exports "^2.0.0"
+    slash "^3.0.0"
+
+jest-runner@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.7.0.tgz#809af072d408a53dcfd2e849a4c976d3132f718e"
+  integrity sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/environment" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    emittery "^0.13.1"
+    graceful-fs "^4.2.9"
+    jest-docblock "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-leak-detector "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-resolve "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-util "^29.7.0"
+    jest-watcher "^29.7.0"
+    jest-worker "^29.7.0"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
+
+jest-runtime@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.7.0.tgz#efecb3141cf7d3767a3a0cc8f7c9990587d3d817"
+  integrity sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==
+  dependencies:
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/globals" "^29.7.0"
+    "@jest/source-map" "^29.6.3"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    cjs-module-lexer "^1.0.0"
+    collect-v8-coverage "^1.0.0"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+
+jest-snapshot@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
+  integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
     natural-compare "^1.4.0"
-    pretty-format "^23.6.0"
-    semver "^5.5.0"
+    pretty-format "^29.7.0"
+    semver "^7.5.3"
 
-jest-util@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
-  integrity sha512-OS1/0QSbbMF9N93MxF1hUmK93EF3NGQGbbaTBZZk95aytWtWmzxsFWwt/UXIIkfHbPCK1fXTrPklbL+ohuFFOA==
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
   dependencies:
-    callsites "^2.0.0"
-    chalk "^2.0.1"
-    graceful-fs "^4.1.11"
-    is-ci "^1.0.10"
-    jest-message-util "^23.4.0"
-    mkdirp "^0.5.1"
-    slash "^1.0.0"
-    source-map "^0.6.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
 
-jest-validate@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
-  integrity sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==
+jest-validate@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.7.0.tgz#7bf705511c64da591d46b15fce41400d52147d9c"
+  integrity sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==
   dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^22.1.0"
-    leven "^2.1.0"
-    pretty-format "^23.6.0"
+    "@jest/types" "^29.6.3"
+    camelcase "^6.2.0"
+    chalk "^4.0.0"
+    jest-get-type "^29.6.3"
+    leven "^3.1.0"
+    pretty-format "^29.7.0"
 
-jest-watcher@^23.4.0:
-  version "23.4.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
-  integrity sha512-BZGZYXnte/vazfnmkD4ERByi2O2mW+C++W8Sb7dvOnwcSccvCKNQgmcz1L+9hxVD7HWtqymPctIY7v5ZbQGNyg==
+jest-watcher@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.7.0.tgz#7810d30d619c3a62093223ce6bb359ca1b28a2f2"
+  integrity sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    string-length "^2.0.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    ansi-escapes "^4.2.1"
+    chalk "^4.0.0"
+    emittery "^0.13.1"
+    jest-util "^29.7.0"
+    string-length "^4.0.1"
 
-jest-worker@^23.2.0:
-  version "23.2.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
-  integrity sha512-zx0uwPCDxToGfYyQiSHh7T/sKIxQFnQqT6Uug7Y/L7PzEkFITPaufjQe6yaf1OXSnGvKC5Fwol1hIym0zDzyvw==
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
   dependencies:
-    merge-stream "^1.0.1"
+    "@types/node" "*"
+    jest-util "^29.7.0"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
 
-jest@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
-  integrity sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==
+jest@29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
+  integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
   dependencies:
-    import-local "^1.0.0"
-    jest-cli "^23.6.0"
+    "@jest/core" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    import-local "^3.0.2"
+    jest-cli "^29.7.0"
 
-"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
+js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-  integrity sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==
-
-js-yaml@^3.7.0:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+js-yaml@^3.13.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-jsdom@^11.5.1:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
-  integrity sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==
-  dependencies:
-    abab "^2.0.0"
-    acorn "^5.5.3"
-    acorn-globals "^4.1.0"
-    array-equal "^1.0.0"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle "^1.0.0"
-    data-urls "^1.0.0"
-    domexception "^1.0.1"
-    escodegen "^1.9.1"
-    html-encoding-sniffer "^1.0.2"
-    left-pad "^1.3.0"
-    nwsapi "^2.0.7"
-    parse5 "4.0.0"
-    pn "^1.1.0"
-    request "^2.87.0"
-    request-promise-native "^1.0.5"
-    sax "^1.2.4"
-    symbol-tree "^3.2.2"
-    tough-cookie "^2.3.4"
-    w3c-hr-time "^1.0.1"
-    webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.3"
-    whatwg-mimetype "^2.1.0"
-    whatwg-url "^6.4.1"
-    ws "^5.2.0"
-    xml-name-validator "^3.0.0"
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-jsesc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
-  integrity sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-json-schema-traverse@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
-  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+kleur@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
+  integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-json-schema@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
-  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-json-stringify-safe@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
-  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
-
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-  integrity sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==
-
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.4.0"
-    verror "1.10.0"
-
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
-
-kleur@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"
-  integrity sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ==
-
-lcid@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
-  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
-  dependencies:
-    invert-kv "^2.0.0"
-
-left-pad@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-  integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
-
-leven@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
-  integrity sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==
-
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 linguist-languages@^7.5.1:
   version "7.26.1"
   resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.26.1.tgz#908a66f5247d8b2df952f1ea69d17bbfd1e4e017"
   integrity sha512-B9O5pDocOkfswmA0qKrqdfeua1TxeQ5PPWdsuo5QRXFv2N0tB3plY+DVWvSWiGkjdqKNU3KBjJYHs/jRXG0adw==
 
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  integrity sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
+    p-locate "^4.1.0"
 
-locate-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
-  integrity sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
-    p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
-
-lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-loose-envify@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
-  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
-  dependencies:
-    js-tokens "^3.0.0 || ^4.0.0"
+    yallist "^3.0.2"
 
 luaparse@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/luaparse/-/luaparse-0.2.1.tgz#aa8f56132b0de97d37f3c991a9df42e0e17f656c"
   integrity sha512-VKBcryd5nJte4ZNR29NOk8F/UkMipjeb4yoxcSS51z6QAzg9DXUC2WsfLniS0J1eh3pr/ZL3e9ha6V8fhoLbBQ==
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -2424,38 +1676,12 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-map-age-cleaner@^0.1.1, map-age-cleaner@^0.1.3:
+map-age-cleaner@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
   dependencies:
     p-defer "^1.0.0"
-
-map-cache@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
-  integrity sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==
-
-map-visit@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
-  integrity sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==
-  dependencies:
-    object-visit "^1.0.0"
-
-math-random@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
-  integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
-
-mem@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
-  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
-  dependencies:
-    map-age-cleaner "^0.1.1"
-    mimic-fn "^2.0.0"
-    p-is-promise "^2.0.0"
 
 mem@^8.0.0:
   version "8.1.1"
@@ -2465,69 +1691,20 @@ mem@^8.0.0:
     map-age-cleaner "^0.1.3"
     mimic-fn "^3.1.0"
 
-merge-stream@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
-  integrity sha512-e6RM36aegd4f+r8BZCcYXlO2P3H6xbUM6ktL2Xmf45GAOit9bI4z6/3VU7JwllVO1L7u0UDSg/EhzQ5lmMLolA==
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+micromatch@^4.0.4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
-    readable-stream "^2.0.1"
+    braces "^3.0.3"
+    picomatch "^2.3.1"
 
-merge@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
-
-micromatch@^2.3.11:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
-  integrity sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==
-  dependencies:
-    arr-diff "^2.0.0"
-    array-unique "^0.2.1"
-    braces "^1.8.2"
-    expand-brackets "^0.1.4"
-    extglob "^0.3.1"
-    filename-regex "^2.0.0"
-    is-extglob "^1.0.0"
-    is-glob "^2.0.1"
-    kind-of "^3.0.2"
-    normalize-path "^2.0.1"
-    object.omit "^2.0.0"
-    parse-glob "^3.0.4"
-    regex-cache "^0.4.2"
-
-micromatch@^3.1.4:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
-  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
-  dependencies:
-    arr-diff "^4.0.0"
-    array-unique "^0.3.2"
-    braces "^2.3.1"
-    define-property "^2.0.2"
-    extend-shallow "^3.0.2"
-    extglob "^2.0.4"
-    fragment-cache "^0.2.1"
-    kind-of "^6.0.2"
-    nanomatch "^1.2.9"
-    object.pick "^1.3.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.2"
-
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
-mimic-fn@^2.0.0:
+mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -2537,400 +1714,156 @@ mimic-fn@^3.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
   integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
-minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1:
+minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
-  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-mixin-deep@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
-  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
-  dependencies:
-    for-in "^1.0.2"
-    is-extendable "^1.0.1"
-
-mkdirp@^0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
-
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
-ms@^2.1.1:
+ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nan@^2.12.1:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
-  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
 
 nanoid@^2.1.0:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
   integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
-nanomatch@^1.2.9:
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
-  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
-  dependencies:
-    arr-diff "^4.0.0"
-    array-unique "^0.3.2"
-    define-property "^2.0.2"
-    extend-shallow "^3.0.2"
-    fragment-cache "^0.2.1"
-    is-windows "^1.0.2"
-    kind-of "^6.0.2"
-    object.pick "^1.3.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-neo-async@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
-  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-nice-try@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
-  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-notifier@^5.2.1:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.5.tgz#0cbc1a2b0f658493b4025775a13ad938e96091ef"
-  integrity sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==
+node-releases@^2.0.36:
+  version "2.0.48"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.48.tgz#4da73d040ada751fc9959d993f27de48792e3b7d"
+  integrity sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==
+
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
-    growly "^1.3.0"
-    is-wsl "^1.1.0"
-    semver "^5.5.0"
-    shellwords "^0.1.1"
-    which "^1.3.0"
+    path-key "^3.0.0"
 
-normalize-package-data@^2.3.2:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
-  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
-  dependencies:
-    hosted-git-info "^2.1.4"
-    resolve "^1.10.0"
-    semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-
-normalize-path@^2.0.1, normalize-path@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
-  integrity sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==
-  dependencies:
-    remove-trailing-separator "^1.0.1"
-
-npm-run-path@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
-  integrity sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==
-  dependencies:
-    path-key "^2.0.0"
-
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
-
-nwsapi@^2.0.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
-  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
-
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
-object-assign@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
-object-copy@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
-  integrity sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==
-  dependencies:
-    copy-descriptor "^0.1.0"
-    define-property "^0.2.5"
-    kind-of "^3.0.3"
-
-object-inspect@^1.12.3, object-inspect@^1.9.0:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
-  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
-
-object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
-  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-
-object-visit@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
-  integrity sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==
-  dependencies:
-    isobject "^3.0.0"
-
-object.assign@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
-  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    has-symbols "^1.0.3"
-    object-keys "^1.1.1"
-
-object.getownpropertydescriptors@^2.1.6:
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.7.tgz#7a466a356cd7da4ba8b9e94ff6d35c3eeab5d56a"
-  integrity sha512-PrJz0C2xJ58FNn11XV2lr4Jt5Gzl94qpy9Lu0JlfEj14z88sqbSBJCBEzdlNUCzY2gburhbrwOZ5BHCmuNUy0g==
-  dependencies:
-    array.prototype.reduce "^1.0.6"
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-    safe-array-concat "^1.0.0"
-
-object.omit@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
-  integrity sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==
-  dependencies:
-    for-own "^0.1.4"
-    is-extendable "^0.1.1"
-
-object.pick@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
-  integrity sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==
-  dependencies:
-    isobject "^3.0.1"
-
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
-optionator@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
-  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.6"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    word-wrap "~1.2.3"
-
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-  integrity sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==
-
-os-locale@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
-  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
-  dependencies:
-    execa "^1.0.0"
-    lcid "^2.0.0"
-    mem "^4.0.0"
-
-os-tmpdir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
+    mimic-fn "^2.1.0"
 
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==
 
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
-
-p-is-promise@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
-  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
-
-p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
-    p-try "^1.0.0"
+    p-try "^2.0.0"
 
-p-locate@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
-  integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
+p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
-    p-limit "^1.1.0"
+    yocto-queue "^0.1.0"
 
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
-
-parse-glob@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
-  integrity sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
-    glob-base "^0.3.0"
-    is-dotfile "^1.0.0"
-    is-extglob "^1.0.0"
-    is-glob "^2.0.0"
+    p-limit "^2.2.0"
 
-parse-json@^2.2.0:
+p-try@^2.0.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
-  integrity sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==
-  dependencies:
-    error-ex "^1.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-parse5@4.0.0:
+parse-json@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
+path-exists@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-pascalcase@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
-  integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
-
-path-exists@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  integrity sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==
-  dependencies:
-    pinkie-promise "^2.0.0"
-
-path-exists@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
-  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
-
-path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
+path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
-path-key@^2.0.0, path-key@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
-  integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.5, path-parse@^1.0.7:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
-
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  integrity sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
 php-parser@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.0.2.tgz#a86dbbc110e57378cba71ab4cd9b0d18f3872ac3"
   integrity sha512-a7y1+odEGsceLDLpu7oNyspZ0pK8FMWJOoim4/yd82AtnEZNLdCLZ67arnOQZ9K0lHJiSp4/7lVUpGELVxE14w==
 
-pify@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-  integrity sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-pinkie-promise@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
-  integrity sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==
+picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+
+pirates@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
+  integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
-    pinkie "^2.0.0"
+    find-up "^4.0.0"
 
-pinkie@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-  integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
-
-pkg-dir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
-  integrity sha512-ojakdnUgL5pzJYWw2AIDEupaQCX5OPbM688ZevubICjdIX01PRSYKqm33fJoCOJBRseYCTUlQRnBNX+Pchaejw==
-  dependencies:
-    find-up "^2.1.0"
-
-pn@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
-  integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-
-posix-character-classes@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
-  integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
-
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
-
-preserve@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-  integrity sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==
-
-prettier-plugin-svelte@^2.3.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz#e1abbe5689e8a926c60b8bc42e61233556ca90d1"
-  integrity sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==
+prettier-plugin-svelte@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.3.1.tgz#926184a490549688dbea0a8d61c1b1ae20218368"
+  integrity sha512-F1/r6OYoBq8Zgurhs1MN25tdrhPw0JW5JjioPRqpxbYdmrZ3gY/DzHGs0B6zwd4DLyRsfGB2gqhxUCbHt/D1fw==
 
 prettier@>=1.10, prettier@^3.0.3:
   version "3.0.3"
@@ -2942,364 +1875,91 @@ prettier@^1.16.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-format@^23.6.0:
-  version "23.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
-  integrity sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
   dependencies:
-    ansi-regex "^3.0.0"
-    ansi-styles "^3.2.0"
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
 
-private@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
-  integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
-
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
-prompts@^0.1.9:
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
-  integrity sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==
+prompts@^2.0.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
+  integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
   dependencies:
-    kleur "^2.0.1"
-    sisteransi "^0.1.1"
+    kleur "^3.0.3"
+    sisteransi "^1.0.5"
 
-psl@^1.1.28:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+pure-rand@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
+  integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
-punycode@^2.1.0, punycode@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
-  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
-
-randomatic@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.1.1.tgz#b776efc59375984e36c537b2f51a1f0aff0da1ed"
-  integrity sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==
-  dependencies:
-    is-number "^4.0.0"
-    kind-of "^6.0.0"
-    math-random "^1.0.1"
-
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  integrity sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==
-  dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
-
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
-  integrity sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==
-  dependencies:
-    load-json-file "^1.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
-
-readable-stream@^2.0.1:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-realpath-native@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
-  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
-  dependencies:
-    util.promisify "^1.0.0"
-
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
-
-regex-cache@^0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
-  integrity sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==
-  dependencies:
-    is-equal-shallow "^0.1.3"
-
-regex-not@^1.0.0, regex-not@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
-  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
-  dependencies:
-    extend-shallow "^3.0.2"
-    safe-regex "^1.1.0"
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 regexp-to-ast@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz#56c73856bee5e1fef7f73a00f1473452ab712a24"
   integrity sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==
 
-regexp.prototype.flags@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz#90ce989138db209f81492edd734183ce99f9677e"
-  integrity sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    set-function-name "^2.0.0"
-
-remove-trailing-separator@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
-  integrity sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==
-
-repeat-element@^1.1.2:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
-  integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
-
-repeat-string@^1.5.2, repeat-string@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-  integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
-
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  integrity sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==
-  dependencies:
-    is-finite "^1.0.0"
-
-request-promise-core@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
-  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
-  dependencies:
-    lodash "^4.17.19"
-
-request-promise-native@^1.0.5:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
-  integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
-  dependencies:
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request@^2.87.0:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-require-main-filename@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-  integrity sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==
-
-resolve-cwd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
-  integrity sha512-ccu8zQTrzVr954472aUVPLEcB3YpKSYR3cg/3lo1okzobPBM+1INXBbBZlDbnI/hbEocnf8j0QVo43hQKrbchg==
-  dependencies:
-    resolve-from "^3.0.0"
-
-resolve-from@^3.0.0:
+resolve-cwd@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
-  integrity sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==
-
-resolve-url@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-  integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
-
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-  integrity sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==
-
-resolve@^1.10.0:
-  version "1.22.6"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.6.tgz#dd209739eca3aef739c626fea1b4f3c506195362"
-  integrity sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
-    is-core-module "^2.13.0"
+    resolve-from "^5.0.0"
+
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve.exports@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
+  integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
+
+resolve@^1.20.0:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-ret@~0.1.10:
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
-  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+semver@^6.3.0, semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-rimraf@^2.5.4, rimraf@^2.6.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
+semver@^7.5.3, semver@^7.5.4:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
-rsvp@^3.3.3:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
-  integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
-
-safe-array-concat@^1.0.0, safe-array-concat@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.0.1.tgz#91686a63ce3adbea14d61b14c99572a8ff84754c"
-  integrity sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.2.1"
-    has-symbols "^1.0.3"
-    isarray "^2.0.5"
-
-safe-buffer@^5.0.1, safe-buffer@^5.1.2:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-regex-test@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
-  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.1.3"
-    is-regex "^1.1.4"
-
-safe-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
-  integrity sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==
-  dependencies:
-    ret "~0.1.10"
-
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sane@^2.0.0:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
-  integrity sha512-OuZwD1QJ2R9Dbnhd7Ur8zzD8l+oADp9npyxK63Q9nZ4AjhB2QwDQcQlD8iuUsGm5AZZqtEuCaJvK1rxGRxyQ1Q==
-  dependencies:
-    anymatch "^2.0.0"
-    capture-exit "^1.2.0"
-    exec-sh "^0.2.0"
-    fb-watchman "^2.0.0"
-    micromatch "^3.1.4"
-    minimist "^1.1.1"
-    walker "~1.0.5"
-    watch "~0.18.0"
-  optionalDependencies:
-    fsevents "^1.2.3"
-
-sax@^1.2.4:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
-  integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
-
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
-set-blocking@^2.0.0:
+shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
-
-set-function-name@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.1.tgz#12ce38b7954310b9f61faa12701620a0c882793a"
-  integrity sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
-    define-data-property "^1.0.1"
-    functions-have-names "^1.2.3"
-    has-property-descriptors "^1.0.0"
+    shebang-regex "^3.0.0"
 
-set-value@^2.0.0, set-value@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
-  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
-
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
-  dependencies:
-    shebang-regex "^1.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
-
-shellwords@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shortid@^2.2.8:
   version "2.2.16"
@@ -3308,511 +1968,156 @@ shortid@^2.2.8:
   dependencies:
     nanoid "^2.1.0"
 
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
-  dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
-
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-sisteransi@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
-  integrity sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==
+sisteransi@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
+  integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-  integrity sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-snapdragon-node@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
-  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
-  dependencies:
-    define-property "^1.0.0"
-    isobject "^3.0.0"
-    snapdragon-util "^3.0.1"
-
-snapdragon-util@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
-  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
-  dependencies:
-    kind-of "^3.2.0"
-
-snapdragon@^0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
-  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
-  dependencies:
-    base "^0.11.1"
-    debug "^2.2.0"
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    map-cache "^0.2.2"
-    source-map "^0.5.6"
-    source-map-resolve "^0.5.0"
-    use "^3.1.0"
-
-source-map-resolve@^0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
-  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
-  dependencies:
-    atob "^2.1.2"
-    decode-uri-component "^0.2.0"
-    resolve-url "^0.2.1"
-    source-map-url "^0.4.0"
-    urix "^0.1.0"
-
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
-  dependencies:
-    source-map "^0.5.6"
-
-source-map-support@^0.5.6:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-url@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
-  integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
-
-source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-spdx-correct@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
-  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
-  dependencies:
-    spdx-expression-parse "^3.0.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-exceptions@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
-  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
-
-spdx-expression-parse@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
-  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz#a14f64e0954f6e25cc6587bd4f392522db0d998f"
-  integrity sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==
-
-split-string@^3.0.1, split-string@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
-  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
-  dependencies:
-    extend-shallow "^3.0.0"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sshpk@^1.7.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
-  integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
-
-stack-utils@^1.0.1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
-  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
+stack-utils@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
+  integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
 
-static-extend@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
-  integrity sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==
+string-length@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
+  integrity sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
   dependencies:
-    define-property "^0.2.5"
-    object-copy "^0.1.0"
+    char-regex "^1.0.2"
+    strip-ansi "^6.0.0"
 
-stealthy-require@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-  integrity sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==
-
-string-length@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
-  integrity sha512-Qka42GGrS8Mm3SZ+7cH8UXiIWI867/b/Z/feQSpQx/rbfB8UGknGEZVaUQMOUVj+soY6NpWAxily63HI1OckVQ==
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
-    astral-regex "^1.0.0"
-    strip-ansi "^4.0.0"
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
+    ansi-regex "^5.0.1"
 
-string-width@^2.0.0, string-width@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
-string.prototype.trim@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz#f9ac6f8af4bd55ddfa8895e6aea92a96395393bd"
-  integrity sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-
-string.prototype.trimend@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz#1bb3afc5008661d73e2dc015cd4853732d6c471e"
-  integrity sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-
-string.prototype.trimstart@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz#d4cdb44b83a4737ffbac2d406e405d43d0184298"
-  integrity sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
-
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
-  dependencies:
-    ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
+strip-bom@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
-  dependencies:
-    ansi-regex "^3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
-strip-bom@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
-
-strip-bom@^2.0.0:
+strip-final-newline@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  integrity sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
-    is-utf8 "^0.2.0"
+    has-flag "^4.0.0"
 
-strip-eof@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
-  integrity sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
-
-supports-color@^3.1.2:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==
+supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
-    has-flag "^1.0.0"
-
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
+    has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-symbol-tree@^3.2.2:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
-  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
-test-exclude@^4.2.1:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.3.tgz#a9a5e64474e4398339245a0a769ad7c2f4a97c20"
-  integrity sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
   dependencies:
-    arrify "^1.0.1"
-    micromatch "^2.3.11"
-    object-assign "^4.1.0"
-    read-pkg-up "^1.0.1"
-    require-main-filename "^1.0.1"
-
-throat@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
-  integrity sha512-wCVxLDcFxw7ujDxaeJC6nfl2XfHJNYs8yUYJnvMgtPEFlttP9tHSfRUv2vBe6C4hkVFPWoP1P6ZccbYjmSEkKA==
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
 
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==
-
-to-object-path@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
-  integrity sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
-    kind-of "^3.0.2"
+    is-number "^7.0.0"
 
-to-regex-range@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
-  integrity sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
+
+update-browserslist-db@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
   dependencies:
-    is-number "^3.0.0"
-    repeat-string "^1.6.1"
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
 
-to-regex@^3.0.1, to-regex@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
-  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+v8-to-istanbul@^9.0.1:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
   dependencies:
-    define-property "^2.0.2"
-    extend-shallow "^3.0.2"
-    regex-not "^1.0.2"
-    safe-regex "^1.1.0"
-
-tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
-tr46@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  integrity sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==
-  dependencies:
-    punycode "^2.1.0"
-
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-  integrity sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
-  dependencies:
-    safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
-
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
-  dependencies:
-    prelude-ls "~1.1.2"
-
-typed-array-buffer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz#18de3e7ed7974b0a729d3feecb94338d1472cd60"
-  integrity sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==
-  dependencies:
-    call-bind "^1.0.2"
-    get-intrinsic "^1.2.1"
-    is-typed-array "^1.1.10"
-
-typed-array-byte-length@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz#d787a24a995711611fb2b87a4052799517b230d0"
-  integrity sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==
-  dependencies:
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    has-proto "^1.0.1"
-    is-typed-array "^1.1.10"
-
-typed-array-byte-offset@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz#cbbe89b51fdef9cd6aaf07ad4707340abbc4ea0b"
-  integrity sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    has-proto "^1.0.1"
-    is-typed-array "^1.1.10"
-
-typed-array-length@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
-  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
-  dependencies:
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    is-typed-array "^1.1.9"
-
-uglify-js@^3.1.4:
-  version "3.17.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
-  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
-
-unbox-primitive@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
-  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
-  dependencies:
-    call-bind "^1.0.2"
-    has-bigints "^1.0.2"
-    has-symbols "^1.0.3"
-    which-boxed-primitive "^1.0.2"
-
-union-value@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
-  integrity sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
-  dependencies:
-    arr-union "^3.1.0"
-    get-value "^2.0.6"
-    is-extendable "^0.1.1"
-    set-value "^2.0.1"
-
-unset-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
-  integrity sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==
-  dependencies:
-    has-value "^0.3.1"
-    isobject "^3.0.0"
-
-uri-js@^4.2.2:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
-  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
-  dependencies:
-    punycode "^2.1.0"
-
-urix@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-  integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
-
-use@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
-  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
-
-util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-util.promisify@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.2.tgz#02b3dbadbb80071eee4c43aed58747afdfc516db"
-  integrity sha512-PBdZ03m1kBnQ5cjjO0ZvJMJS+QsbyIcFwi4hY4U76OQsCO9JrOYjbCFgIF76ccFg9xnJo7ZHPkqyj1GqmdS7MA==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    for-each "^0.3.3"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
-    object.getownpropertydescriptors "^2.1.6"
-    safe-array-concat "^1.0.0"
-
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-validate-npm-package-license@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
-  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
-  dependencies:
-    spdx-correct "^3.0.0"
-    spdx-expression-parse "^3.0.0"
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
 
 vim-driver@^1.0.0:
   version "1.0.1"
@@ -3822,167 +2127,71 @@ vim-driver@^1.0.0:
     colors "^1.3.0"
     shortid "^2.2.8"
 
-w3c-hr-time@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
-  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
-  dependencies:
-    browser-process-hrtime "^1.0.0"
-
-walker@~1.0.5:
+walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
 
-watch@~0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
-  integrity sha512-oUcoHFG3UF2pBlHcMORAojsN09BfqSfWYWlR3eSSjUFR7eBEx53WT2HX/vZeVTTIVCGShcazb+t6IcBRCNXqvA==
-  dependencies:
-    exec-sh "^0.2.0"
-    minimist "^1.2.0"
-
-webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
-  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
-  dependencies:
-    iconv-lite "0.4.24"
-
-whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
-  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url@^6.4.1:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
-  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
-
-whatwg-url@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
-  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
-
-which-boxed-primitive@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
-  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
-  dependencies:
-    is-bigint "^1.0.1"
-    is-boolean-object "^1.1.0"
-    is-number-object "^1.0.4"
-    is-string "^1.0.5"
-    is-symbol "^1.0.3"
-
-which-module@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
-  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
-
-which-typed-array@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
-  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
-
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
-  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@~1.2.3:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
-  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
-
-wordwrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
-
-wrap-ansi@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
-  integrity sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-write-file-atomic@^2.1.0:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
-  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+write-file-atomic@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
+  integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
   dependencies:
-    graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
-    signal-exit "^3.0.2"
+    signal-exit "^3.0.7"
 
-ws@^5.2.0:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
-  integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.3.1:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
-    async-limiter "~1.0.0"
-
-xml-name-validator@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
-  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-y18n@^3.2.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
-  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
-
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha512-CswCfdOgCr4MMsT1GzbEJ7Z2uYudWyrGX8Bgh/0eyCzj/DXWdKq6a/ADufkzI1WAOIW6jYaXJvRyLhDO0kfqBw==
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs@^11.0.0:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.1.tgz#5052efe3446a4df5ed669c995886cc0f13702766"
-  integrity sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^3.1.0"
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,7 @@
     "@jridgewell/sourcemap-codec" "^1.5.0"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/remapping@^2.3.5":
+"@jridgewell/remapping@^2.3.4", "@jridgewell/remapping@^2.3.5":
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
   integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
@@ -499,7 +499,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -512,36 +512,20 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@prettier/plugin-lua@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@prettier/plugin-lua/-/plugin-lua-0.0.1.tgz#60498b7e3ca23bf390a9923c8d9072ca4020ce61"
-  integrity sha512-fZ6hUPKfZq3KY4zWSQpdvPrbi1LtxPXJvFJYMJHxt8HxRyyySlFWspKhgcIdlaZ1EL3cMyP2muPvvDpM7GbyBQ==
+"@prettier/plugin-php@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@prettier/plugin-php/-/plugin-php-0.25.0.tgz#2f0c70248b4507b28c6936742e70816b178c0724"
+  integrity sha512-hi0NhucbspYqw5pZYKywEk5CxsBwA0pBcG6K08AZw7OQDoUm4Hhbxql7z/SzQGeTRHqak5PwDnVNgttZiZdrlg==
   dependencies:
-    luaparse "0.2.1"
+    linguist-languages "^8.0.0"
+    php-parser "^3.4.0"
 
-"@prettier/plugin-php@^0.16.3":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@prettier/plugin-php/-/plugin-php-0.16.3.tgz#74867210079ba3c0c3ae843029d76e25ff0aadf3"
-  integrity sha512-DNidzeGpP+/wmcCAZNSHxgoAnhEosYG+no4jJRqln19e1o3Okpuir/2JMxb07VCwdG50IWjtNgVwNPVl4uj0Hg==
+"@prettier/plugin-xml@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@prettier/plugin-xml/-/plugin-xml-3.4.2.tgz#ad0b46a6d73ae16cefb744c98c0ccc604c51f98a"
+  integrity sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==
   dependencies:
-    linguist-languages "^7.5.1"
-    mem "^8.0.0"
-    php-parser "3.0.2"
-
-"@prettier/plugin-ruby@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-0.8.0.tgz#e305cb31310d865805b2db7ddfc2cc9273149505"
-  integrity sha512-EbhlgBzeHv6P0jnjMf6MCmgz28C6MCB0yU81enR7605mrUzUO8wg7RMaWCJsbfp7TRs5u9OqimMmib1Ivi4c0A==
-  dependencies:
-    prettier "^1.16.4"
-
-"@prettier/plugin-xml@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@prettier/plugin-xml/-/plugin-xml-0.7.2.tgz#f4b6e7c45a9e36663d403828e380e8a4c6a12106"
-  integrity sha512-c6i6OQ2y9kvWeUTrfkwHy+jdJXI3bpO8TT9EoVjJIEAApj5gLtJ/O2D9qthxWXh5zbipngueDEC2CT6tBZzBdA==
-  dependencies:
-    "@xml-tools/parser" "^1.0.2"
-    prettier ">=1.10"
+    "@xml-tools/parser" "^1.0.11"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
@@ -561,6 +545,11 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@sveltejs/acorn-typescript@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz#72376d9f46c04be82b714b1c33f0956911a7a6d6"
+  integrity sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -594,6 +583,11 @@
   integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
   dependencies:
     "@babel/types" "^7.28.2"
+
+"@types/estree@^1.0.5", "@types/estree@^1.0.6":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
+  integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
 
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
@@ -633,6 +627,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -645,12 +644,17 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@xml-tools/parser@^1.0.2":
+"@xml-tools/parser@^1.0.11":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@xml-tools/parser/-/parser-1.0.11.tgz#a118a14099ea5c3c537e4781fad2fc195b57f8ff"
   integrity sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==
   dependencies:
     chevrotain "7.1.1"
+
+acorn@^8.12.1:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -688,6 +692,16 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.1.tgz#ebcb2c0d7fc43e68e4cb22f774d1209cb627ab42"
+  integrity sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==
+
+axobject-query@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
+  integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -859,6 +873,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -940,6 +959,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+devalue@^5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/devalue/-/devalue-5.8.1.tgz#f27290d3a324e2eb20c2714369b01b8ec4de4c61"
+  integrity sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==
+
 diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
@@ -981,6 +1005,18 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+esm-env@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esm-env/-/esm-env-1.2.2.tgz#263c9455c55861f41618df31b20cb571fc20b75e"
+  integrity sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==
+
+esrap@^2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/esrap/-/esrap-2.2.11.tgz#8cdff4ea4f7132dadb4da896f7af858b281c5a5e"
+  integrity sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -1166,6 +1202,13 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-reference@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.3.tgz#9ef7bf9029c70a67b2152da4adf57c23d718910f"
+  integrity sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==
+  dependencies:
+    "@types/estree" "^1.0.6"
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -1630,10 +1673,15 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linguist-languages@^7.5.1:
-  version "7.26.1"
-  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.26.1.tgz#908a66f5247d8b2df952f1ea69d17bbfd1e4e017"
-  integrity sha512-B9O5pDocOkfswmA0qKrqdfeua1TxeQ5PPWdsuo5QRXFv2N0tB3plY+DVWvSWiGkjdqKNU3KBjJYHs/jRXG0adw==
+linguist-languages@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-8.2.0.tgz#d8f60eeaf0a97f04d5a4f6eb6190e39ebaf200d4"
+  integrity sha512-KCUUH9x97QWYU0SXOCGxUrZR6cSfuQrMhABB7L/0I8N0LXOeaKe7+RZs7FAwvWCV2qKfZ4Wv1luLq4OfMezSJg==
+
+locate-character@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
+  integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -1649,10 +1697,12 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-luaparse@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/luaparse/-/luaparse-0.2.1.tgz#aa8f56132b0de97d37f3c991a9df42e0e17f656c"
-  integrity sha512-VKBcryd5nJte4ZNR29NOk8F/UkMipjeb4yoxcSS51z6QAzg9DXUC2WsfLniS0J1eh3pr/ZL3e9ha6V8fhoLbBQ==
+magic-string@^0.30.11:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 make-dir@^4.0.0:
   version "4.0.0"
@@ -1667,21 +1717,6 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
-
-map-age-cleaner@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
-  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
-  dependencies:
-    p-defer "^1.0.0"
-
-mem@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-8.1.1.tgz#cf118b357c65ab7b7e0817bdf00c8062297c0122"
-  integrity sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==
-  dependencies:
-    map-age-cleaner "^0.1.3"
-    mimic-fn "^3.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -1700,11 +1735,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
-  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 minimatch@3.1.5, minimatch@^3.0.4, minimatch@^3.1.1:
   version "3.1.5"
@@ -1758,11 +1788,6 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-p-defer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
-  integrity sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -1820,10 +1845,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-php-parser@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.0.2.tgz#a86dbbc110e57378cba71ab4cd9b0d18f3872ac3"
-  integrity sha512-a7y1+odEGsceLDLpu7oNyspZ0pK8FMWJOoim4/yd82AtnEZNLdCLZ67arnOQZ9K0lHJiSp4/7lVUpGELVxE14w==
+php-parser@^3.4.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.7.0.tgz#b40b82dc9ba2ad3068b418130f50a84b663d29ac"
+  integrity sha512-JRc1t78GZAEa+MuzVC5A5RJS1NDFTS4UnprUEu/NnsN9cyHbGZLUqghO9IQZUSCay62HYQiWd3PxyWAEF45zmA==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -1847,20 +1872,15 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prettier-plugin-svelte@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.3.1.tgz#926184a490549688dbea0a8d61c1b1ae20218368"
-  integrity sha512-F1/r6OYoBq8Zgurhs1MN25tdrhPw0JW5JjioPRqpxbYdmrZ3gY/DzHGs0B6zwd4DLyRsfGB2gqhxUCbHt/D1fw==
+prettier-plugin-svelte@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz#d230133b2ea3d566f21b11b763fd372fb9268958"
+  integrity sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==
 
-prettier@>=1.10, prettier@^3.0.3:
+prettier@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
   integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
-
-prettier@^1.16.4:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^29.7.0:
   version "29.7.0"
@@ -2041,6 +2061,28 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svelte@^5.56.3:
+  version "5.56.3"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-5.56.3.tgz#5cd7c11f738930e4c500c57e31827888168ba6e4"
+  integrity sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.4"
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@sveltejs/acorn-typescript" "^1.0.10"
+    "@types/estree" "^1.0.5"
+    "@types/trusted-types" "^2.0.7"
+    acorn "^8.12.1"
+    aria-query "5.3.1"
+    axobject-query "^4.1.0"
+    clsx "^2.1.1"
+    devalue "^5.8.1"
+    esm-env "^1.2.1"
+    esrap "^2.2.11"
+    is-reference "^3.0.3"
+    locate-character "^3.0.0"
+    magic-string "^0.30.11"
+    zimmerframe "^1.1.2"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -2162,3 +2204,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zimmerframe@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/zimmerframe/-/zimmerframe-1.1.4.tgz#0352b5cafad3ad4526b0a526a9a52d9c040d865b"
+  integrity sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==


### PR DESCRIPTION
This PR gives vim-prettier a real, tested compatibility policy instead of just hoping for the best. Vim, Neovim, Node, and Prettier versions are now tracked and checked in CI.

What's new:

🐛 Fixed a Vim 9.1 crash — that annoying E930 error (Cannot use :redir inside execute()) when detecting the Prettier CLI version is gone. We just run the executable directly now.
📁 Smarter executable lookup — instead of only checking Vim's cwd, we now walk up from the buffer's own directory to find the right Prettier executable.
🔒 Safer command building — paths with spaces or quotes won't break things anymore. We build proper argv lists for modern Vim/Neovim job APIs, with the old shell-string fallback still there for legacy/sync paths.
⚡ No more async data loss — async jobs are tracked per-buffer, we check b:changedtick before swapping in formatted output, and :PrettierAsync won't randomly write your file to disk anymore.
🧪 Cleaned up the test harness — upgraded Jest (23 → 29), dropped some vulnerable old deps (jsdom, request, Babel 6), and swapped vim-driver for a tiny zero-dependency runner we wrote ourselves (in tests/vim-driver/). yarn audit is clean now.
📚 Docs synced up — README and doc/prettier.txt now match the 2.0.0-beta.1 release, including the g:prettier#config#plugins option and setup tips.

Test Plan
Ran everything locally and on CI — all green ✅
Local:

yarn test:formatting:core
yarn test:smoke
yarn lint
git diff --check

Local editor matrix (via our new Docker runner):
yarn test:editors:docker
Covers Vim 8.2, Vim stable, Neovim 0.9.5, and Neovim stable.
CI matrix (Compatibility Smoke workflow, run 27897350091):

Editors: Vim 8.2 (v8.2.5172), Vim stable, Neovim 0.9.5, Neovim stable
Prettier: bundled 3.0.3, project-local 2.8.8, latest
Languages: JS, JSX, TS, TSX, CSS, SCSS, Less, HTML, Vue, JSON, YAML, GraphQL, Markdown